### PR TITLE
Use generic fields

### DIFF
--- a/OneOf.Tests/DefaultConstructorTests.cs
+++ b/OneOf.Tests/DefaultConstructorTests.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+using OneOf;
+
+namespace OneOf.Tests
+{
+    public class DefaultConstructorTests
+    {
+        [Test]
+        public void DefaultConstructorSetsValueToDefaultValueOfT0()
+        {
+            var x = new OneOf<int, bool>();
+            var result = x.Match(n => n == default(int), n => false);
+        }
+    }
+}

--- a/OneOf.Tests/MixedReferenceAndValueTypeTests.cs
+++ b/OneOf.Tests/MixedReferenceAndValueTypeTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using OneOf;
+
+namespace OneOf.Tests
+{
+    public class RetryStrategy : OneOfBase<RetryStrategy.Never, int>
+    {
+        private RetryStrategy() { }
+        private RetryStrategy(int attempts):base(1, value1:attempts) { }
+
+        public static implicit operator RetryStrategy(int attempts)
+        {
+            return new RetryStrategy(attempts);
+        }
+        public class Never : RetryStrategy
+        {
+            internal int _attempts = 0;
+        }
+
+        public int Attempts => Match(n => n._attempts, n => n);
+    }
+
+    public class MixedReferenceAndValueTypeTests
+    {
+        [Test]
+        public void CanMatchOnReferenceAndValue()
+        {
+            RetryStrategy strat = 5;
+            Assert.AreEqual(strat.Attempts, 5);
+            strat = new RetryStrategy.Never();
+            Assert.AreEqual(strat.Attempts, 0);
+        }
+    }
+}

--- a/OneOf.Tests/OneOf.Tests.csproj
+++ b/OneOf.Tests/OneOf.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseClassTests.cs" />
+    <Compile Include="DefaultConstructorTests.cs" />
     <Compile Include="EqualsTests.cs" />
     <Compile Include="OneOfJsonConverter.cs" />
     <Compile Include="Serialization.cs" />

--- a/OneOf.Tests/OneOf.Tests.csproj
+++ b/OneOf.Tests/OneOf.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="EqualsTests.cs" />
     <Compile Include="OneOfJsonConverter.cs" />
     <Compile Include="Serialization.cs" />
+    <Compile Include="MixedReferenceAndValueTypeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -25,9 +25,12 @@ namespace OneOf
 
         sb.AppendLine($@"
     public {(isStruct ? "struct" : "class")} {className}<{genericArg}> : IOneOf");
-        for (var j = 0; j < i; j++)
+        if (!isStruct)
         {
-            sb.AppendLine($"        where T{j} : class");
+            for (var j = 0; j < i; j++)
+            {
+                sb.AppendLine($"        where T{j} : class");
+            }
         }
         sb.AppendLine("    {");
         for (var j = 0; j < i; j++)

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -131,9 +131,9 @@ namespace OneOf
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (_index == {j} && f{j} != null)
             {{
-                f{j}(AsT{j});
+                f{j}(_value{j});
                 return; 
             }}");
         }
@@ -148,9 +148,9 @@ namespace OneOf
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (_index == {j} && f{j} != null)
             {{
-                return f{j}(AsT{j});
+                return f{j}(_value{j});
             }}");
         }
 
@@ -164,9 +164,9 @@ namespace OneOf
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (_index == {j} && f{j} != null)
             {{
-                return f{j}(AsT{j});
+                return f{j}(_value{j});
             }}");
         }
 

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -25,13 +25,6 @@ namespace OneOf
 
         sb.AppendLine($@"
     public {(isStruct ? "struct" : "class")} {className}<{genericArg}> : IOneOf");
-        if (!isStruct)
-        {
-            for (var j = 0; j < i; j++)
-            {
-                sb.AppendLine($"        where T{j} : class");
-            }
-        }
         sb.AppendLine("    {");
         for (var j = 0; j < i; j++)
         {
@@ -40,7 +33,7 @@ namespace OneOf
 
         sb.Append($@"        readonly int _index;
     
-        {className}(int index");
+        {(isStruct ? "" : "protected ")}{className}(int index");
         for (var j = 0; j < i; j++)
         {
             sb.Append($", T{j} value{j} = default(T{j})");
@@ -59,19 +52,16 @@ namespace OneOf
         if (!isStruct)
         {
             sb.AppendLine($@"
-            protected {className}()
+        protected {className}()
         {{");
 
             for (var j = 0; j < i; j++)
             {
-                sb.AppendLine($@"            {{
-                var value = this as T{j};
-                if (value != null)
-                {{
-                    _index = {j};
-                    _value{j} = value;
-                    return;
-                }}
+                sb.AppendLine($@"            if (this is T{j})
+            {{
+                _index = {j};
+                _value{j} = (T{j})(object)this;
+                return;
             }}");
             }
 

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -25,27 +25,27 @@ namespace OneOf.Structs
     
         sb.AppendLine($@"    public struct OneOfStruct<{genericArg}> : IOneOf
     {{
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfStruct(object value, int index)
         {{
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }}
     
         object IOneOf.Value 
         {{
-            get {{ return value; }}
+            get {{ return _value; }}
         }}
     
         T Get<T>(int index)
         {{
-            if (index != this.index)
+            if (index != _index)
             {{
-                throw new InvalidOperationException($""Cannot return as T{{index}} as result is T{{this.index}}"");
+                throw new InvalidOperationException($""Cannot return as T{{index}} as result is T{{_index}}"");
             }}
-            return (T)value;
+            return (T)_value;
         }}");
         for (var j = 0; j < i; j++)
         {
@@ -53,7 +53,7 @@ namespace OneOf.Structs
 $@"
         public bool IsT{j}
         {{
-            get {{ return index == {j}; }}
+            get {{ return _index == {j}; }}
         }}
         
         public T{j} AsT{j}
@@ -69,15 +69,14 @@ $@"
         }
 
         var matchArgList0 = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Action<T{e}> f{e}"));
-        sb.AppendLine($@"
-        public void Switch({matchArgList0})
+        sb.AppendLine($@"        public void Switch({matchArgList0})
         {{");
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
             {{
-                f{j}(this.AsT{j});
+                f{j}(AsT{j});
                 return; 
             }}");
         }
@@ -93,9 +92,9 @@ $@"
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
             {{
-                return f{j}(this.AsT{j});
+                return f{j}(AsT{j});
             }}");
         }
 
@@ -109,9 +108,9 @@ $@"
 
         for (var j = 0; j < i; j++)
         {
-            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            sb.AppendLine($@"            if (IsT{j} && f{j} != null)
             {{
-                return f{j}(this.AsT{j});
+                return f{j}(AsT{j});
             }}");
         }
 
@@ -127,7 +126,7 @@ $@"
             sb.AppendLine(@"
         protected OneOfBase()
         {
-            this.value = this;");
+            _value = this;");
 
             for (var j = 0; j < i; j++)
             {
@@ -135,7 +134,7 @@ $@"
                 sb.AppendLine($@"
             if (this is T{j})
             {{
-                this.index = {j};
+                _index = {j};
             }}");
             }
 
@@ -145,7 +144,7 @@ $@"
         sb.AppendLine($@"
         bool Equals(OneOfStruct<{genericArg}> other)
         {{
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }}
 
         public override bool Equals(object obj)
@@ -176,7 +175,7 @@ $@"
         {{
             unchecked
             {{
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }}
         }}
     }}

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -2,137 +2,148 @@
 
 void Main()
 {
-	var output = GetContent(true).Dump();
-	var outpath = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "OneOf.cs");
-	File.WriteAllText(outpath.Dump(), output);
+    var output = GetContent(true).Dump();
+    var outpath = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "OneOf.cs");
+    File.WriteAllText(outpath.Dump(), output);
 
-	var output2 = GetContent(false);
-	var outpath2 = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "OneOfBase.cs");
-	File.WriteAllText(outpath2.Dump(), output2);
+    var output2 = GetContent(false);
+    var outpath2 = Path.Combine(Path.GetDirectoryName(Util.CurrentQueryPath), "OneOfBase.cs");
+    File.WriteAllText(outpath2.Dump(), output2);
 }
 
 public string GetContent(bool isStruct)
 {
-	var sb = new StringBuilder();
-	sb.AppendLine(@"
+    var sb = new StringBuilder();
+    sb.AppendLine(@"
 using System;
 
 namespace OneOf.Structs
-{
-	");
-	for (var i = 1; i < 10; i++)
-	{
-		var genericArg = string.Join(", ", Enumerable.Range(0, i).Select(e => "T" + e));
-
-
-
-	
-		sb.AppendLine(string.Format(
-
-@"
-	public struct OneOfStruct<{0}> : IOneOf
+{");
+    for (var i = 1; i < 10; i++)
+    {
+        var genericArg = string.Join(", ", Enumerable.Range(0, i).Select(e => $"T{e}"));
+    
+        sb.AppendLine($@"    public struct OneOfStruct<{genericArg}> : IOneOf
     {{
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfStruct(object value, int index)	    {{ this.value = value; this.index = index;	     }}
-	
-		object IOneOf.Value {{ get {{ return value; }} }}
-	
-	    T Get<T>(int index)
-	    {{
-		    if (index != this.index)
-		    {{
-		    	throw new InvalidOperationException(""Cannot return as T"" + index + "" as result is T"" + this.index);
-            }}
-	        return (T)value;
-	    }}
-", genericArg));
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine(string.Format(
-@"
-        public bool IsT{0} {{ get {{ return index == {0}; }} }}
-        public T{0} AsT{0} {{ get {{ return Get<T{0}>({0}); }} }} 
-        public static implicit operator OneOfStruct<{1}> (T{0} t)
+        readonly object value;
+        readonly int index;
+        
+        OneOfStruct(object value, int index)
         {{
-	         return new OneOfStruct<{1}>(t, {0});
+            this.value = value; 
+            this.index = index;
         }}
-", j, genericArg));
-		}
-
-		var matchArgList0 = string.Join(", ", Enumerable.Range(0, i).Select(e => "Action<T" + e + "> f" + e));
-		sb.AppendLine(string.Format(@"
-	    public void Switch({1})
+    
+        object IOneOf.Value 
         {{
-			", genericArg, matchArgList0));
-
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine(string.Format(@"			if (this.IsT{0} && f{0} != null) {{ f{0}(this.AsT{0}); return; }}", j));
-		}
-
-		sb.AppendLine(string.Format(@"
-	    	throw new InvalidOperationException();
-		}}
-"));
-
-		var matchArgList = string.Join(", ", Enumerable.Range(0, i).Select(e => "Func<T" + e + ", TResult> f" + e));
-		sb.AppendLine(string.Format(@"
-	    public TResult Match<TResult>({1})
+            get {{ return value; }}
+        }}
+    
+        T Get<T>(int index)
         {{
-			", genericArg, matchArgList));
-
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine(string.Format(@"			if (this.IsT{0} && f{0} != null) return f{0}(this.AsT{0});", j));
-		}
-
-		sb.AppendLine(string.Format(@"
-	    	throw new InvalidOperationException();
-		}}
-"));
-
-		var matchArgList2 = string.Join(", ", Enumerable.Range(0, i).Select(e => "Func<T" + e + ", TResult> f" + e + " = null"));
-		sb.AppendLine(string.Format(@"
-	    public TResult MatchSome<TResult>({1}, Func<TResult> otherwise = null)
+            if (index != this.index)
+            {{
+                throw new InvalidOperationException($""Cannot return as T{{index}} as result is T{{this.index}}"");
+            }}
+            return (T)value;
+        }}");
+        for (var j = 0; j < i; j++)
+        {
+            sb.AppendLine(
+$@"
+        public bool IsT{j}
         {{
-			", genericArg, matchArgList2));
+            get {{ return index == {j}; }}
+        }}
+        
+        public T{j} AsT{j}
+        {{
+            get {{ return Get<T{j}>({j}); }}
+        }}
+        
+        public static implicit operator OneOfStruct<{genericArg}> (T{j} t)
+        {{
+             return new OneOfStruct<{genericArg}>(t, {j});
+        }}
+");
+        }
 
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine(string.Format(@"
-			if (this.IsT{0} && f{0} != null) return f{0}(this.AsT{0});", j));
-		}
+        var matchArgList0 = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Action<T{e}> f{e}"));
+        sb.AppendLine($@"
+        public void Switch({matchArgList0})
+        {{");
 
-		sb.AppendLine(string.Format(@"
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}}
-"));
+        for (var j = 0; j < i; j++)
+        {
+            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            {{
+                f{j}(this.AsT{j});
+                return; 
+            }}");
+        }
 
-		if (!isStruct)
-		{
-			sb.AppendLine(@"
-		
-		protected OneOfBase()
-		{
-			this.value = this;");
+        sb.AppendLine(@"            throw new InvalidOperationException();
+        }
+");
 
-			for (var j = 0; j < i; j++)
-			{
-				
-				sb.AppendLine(string.Format(@"
-			if (this is T{0}) this.index = {0};", j));
-			}
+        var matchArgList = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Func<T{e}, TResult> f{e}"));
+        sb.AppendLine($@"
+        public TResult Match<TResult>({matchArgList})
+        {{");
 
-			sb.AppendLine(@"
-		}");
+        for (var j = 0; j < i; j++)
+        {
+            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            {{
+                return f{j}(this.AsT{j});
+            }}");
+        }
 
-		}
-		sb.AppendLine($@"
-		
-		bool Equals(OneOfStruct<{genericArg}> other)
+        sb.AppendLine(@"            throw new InvalidOperationException();
+        }
+");
+
+        var matchArgList2 = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Func<T{e}, TResult> f{e} = null"));
+        sb.AppendLine($@"        public TResult MatchSome<TResult>({matchArgList2}, Func<TResult> otherwise = null)
+        {{");
+
+        for (var j = 0; j < i; j++)
+        {
+            sb.AppendLine($@"            if (this.IsT{j} && f{j} != null)
+            {{
+                return f{j}(this.AsT{j});
+            }}");
+        }
+
+        sb.AppendLine(@"            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }");
+
+        if (!isStruct)
+        {
+            sb.AppendLine(@"
+        protected OneOfBase()
+        {
+            this.value = this;");
+
+            for (var j = 0; j < i; j++)
+            {
+                
+                sb.AppendLine($@"
+            if (this is T{j})
+            {{
+                this.index = {j};
+            }}");
+            }
+
+            sb.AppendLine(@"        }");
+
+        }
+        sb.AppendLine($@"
+        bool Equals(OneOfStruct<{genericArg}> other)
         {{
             return index == other.index && Equals(value, other.value);
         }}
@@ -168,11 +179,11 @@ namespace OneOf.Structs
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }}
         }}
-}}
+    }}
 ");
-	}
-	sb.AppendLine("}");
-	var content = sb.ToString();
-	if (isStruct) return content.Replace(".Structs", "").Replace("OneOfStruct", "OneOf");
-	return content.Replace("struct", "class").Replace(".Structs", "").Replace("OneOfStruct", "OneOfBase");
+    }
+    sb.AppendLine("}");
+    var content = sb.ToString();
+    if (isStruct) return content.Replace(".Structs", "").Replace("OneOfStruct", "OneOf");
+    return content.Replace("struct", "class").Replace(".Structs", "").Replace("OneOfStruct", "OneOfBase");
 }

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -14,8 +14,7 @@ void Main()
 public string GetContent(bool isStruct)
 {
     var sb = new StringBuilder();
-    sb.AppendLine(@"
-using System;
+    sb.AppendLine(@"using System;
 
 namespace OneOf.Structs
 {");
@@ -33,20 +32,40 @@ namespace OneOf.Structs
             _value = value; 
             _index = index;
         }}
+");
     
-        object IOneOf.Value 
-        {{
-            get {{ return _value; }}
-        }}
+        if (!isStruct)
+        {
+            sb.AppendLine(@"        protected OneOfBase()
+        {
+            _value = this;");
+
+            for (var j = 0; j < i; j++)
+            {                
+                sb.AppendLine($@"
+            if (this is T{j})
+            {{
+                _index = {j};
+            }}");
+            }
+
+            sb.AppendLine(@"        }
+");
+        }
+        
+        sb.AppendLine(@"        object IOneOf.Value 
+        {
+            get { return _value; }
+        }
     
         T Get<T>(int index)
-        {{
+        {
             if (index != _index)
-            {{
-                throw new InvalidOperationException($""Cannot return as T{{index}} as result is T{{_index}}"");
-            }}
+            {
+                throw new InvalidOperationException($""Cannot return as T{index} as result is T{_index}"");
+            }
             return (T)_value;
-        }}");
+        }");
         for (var j = 0; j < i; j++)
         {
             sb.AppendLine(
@@ -82,8 +101,7 @@ $@"
         }
 
         sb.AppendLine(@"            throw new InvalidOperationException();
-        }
-");
+        }");
 
         var matchArgList = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Func<T{e}, TResult> f{e}"));
         sb.AppendLine($@"
@@ -120,27 +138,7 @@ $@"
             }
             throw new InvalidOperationException();
         }");
-
-        if (!isStruct)
-        {
-            sb.AppendLine(@"
-        protected OneOfBase()
-        {
-            _value = this;");
-
-            for (var j = 0; j < i; j++)
-            {
-                
-                sb.AppendLine($@"
-            if (this is T{j})
-            {{
-                _index = {j};
-            }}");
-            }
-
-            sb.AppendLine(@"        }");
-
-        }
+        
         sb.AppendLine($@"
         bool Equals(OneOfStruct<{genericArg}> other)
         {{

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -51,9 +51,9 @@ namespace OneOf
 
         public void Switch(Action<T0> f0)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
             throw new InvalidOperationException();
@@ -61,18 +61,18 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
             if (otherwise != null)
             {
@@ -200,14 +200,14 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
             throw new InvalidOperationException();
@@ -215,26 +215,26 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
             if (otherwise != null)
             {
@@ -393,19 +393,19 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
             throw new InvalidOperationException();
@@ -413,34 +413,34 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
             if (otherwise != null)
             {
@@ -630,24 +630,24 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
             throw new InvalidOperationException();
@@ -655,42 +655,42 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
             if (otherwise != null)
             {
@@ -911,29 +911,29 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
             throw new InvalidOperationException();
@@ -941,50 +941,50 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
             if (otherwise != null)
             {
@@ -1236,34 +1236,34 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1271,58 +1271,58 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
             if (otherwise != null)
             {
@@ -1605,39 +1605,39 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1645,66 +1645,66 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
             if (otherwise != null)
             {
@@ -2018,44 +2018,44 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                f7(AsT7);
+                f7(_value7);
                 return; 
             }
             throw new InvalidOperationException();
@@ -2063,74 +2063,74 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
             if (otherwise != null)
             {
@@ -2475,49 +2475,49 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                f7(AsT7);
+                f7(_value7);
                 return; 
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                f8(AsT8);
+                f8(_value8);
                 return; 
             }
             throw new InvalidOperationException();
@@ -2525,82 +2525,82 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                return f8(AsT8);
+                return f8(_value8);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                return f8(AsT8);
+                return f8(_value8);
             }
             if (otherwise != null)
             {

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -3,7 +3,6 @@ using System;
 namespace OneOf
 {
     public struct OneOf<T0> : IOneOf
-        where T0 : class
     {
         readonly T0 _value0;
         readonly int _index;
@@ -127,8 +126,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1> : IOneOf
-        where T0 : class
-        where T1 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -296,9 +293,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -510,10 +504,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -769,11 +759,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -1073,12 +1058,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -1422,13 +1401,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -1816,14 +1788,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
-        where T7 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -2255,15 +2219,6 @@ namespace OneOf
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
-        where T7 : class
-        where T8 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -3,28 +3,29 @@ using System;
 namespace OneOf
 {
     public struct OneOf<T0> : IOneOf
+        where T0 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0))
+        { 
             _index = index;
+            _value0 = value0;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -34,12 +35,19 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0> (T0 t)
+        public static implicit operator OneOf<T0>(T0 t)
         {
-             return new OneOf<T0>(t, 0);
+             return new OneOf<T0>(0, value0: t);
         }
 
         public void Switch(Action<T0> f0)
@@ -76,7 +84,17 @@ namespace OneOf
 
         bool Equals(OneOf<T0> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -86,41 +104,57 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0> && Equals((OneOf<T0>) obj);
+            return obj is OneOf<T0> && Equals((OneOf<T0>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1> : IOneOf
+        where T0 : class
+        where T1 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -130,14 +164,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1> (T0 t)
+        public static implicit operator OneOf<T0, T1>(T0 t)
         {
-             return new OneOf<T0, T1>(t, 0);
+             return new OneOf<T0, T1>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -146,12 +186,19 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1> (T1 t)
+        public static implicit operator OneOf<T0, T1>(T1 t)
         {
-             return new OneOf<T0, T1>(t, 1);
+             return new OneOf<T0, T1>(1, value1: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1)
@@ -201,7 +248,19 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -211,41 +270,65 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1> && Equals((OneOf<T0, T1>) obj);
+            return obj is OneOf<T0, T1> && Equals((OneOf<T0, T1>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -255,14 +338,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2>(T0 t)
         {
-             return new OneOf<T0, T1, T2>(t, 0);
+             return new OneOf<T0, T1, T2>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -271,14 +360,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2>(T1 t)
         {
-             return new OneOf<T0, T1, T2>(t, 1);
+             return new OneOf<T0, T1, T2>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -287,12 +382,19 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2>(T2 t)
         {
-             return new OneOf<T0, T1, T2>(t, 2);
+             return new OneOf<T0, T1, T2>(2, value2: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
@@ -355,7 +457,21 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -365,41 +481,73 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2> && Equals((OneOf<T0, T1, T2>) obj);
+            return obj is OneOf<T0, T1, T2> && Equals((OneOf<T0, T1, T2>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -409,14 +557,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3>(t, 0);
+             return new OneOf<T0, T1, T2, T3>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -425,14 +579,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3>(t, 1);
+             return new OneOf<T0, T1, T2, T3>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -441,14 +601,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3>(t, 2);
+             return new OneOf<T0, T1, T2, T3>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -457,12 +623,19 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3>(t, 3);
+             return new OneOf<T0, T1, T2, T3>(3, value3: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
@@ -538,7 +711,23 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -548,41 +737,81 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3> && Equals((OneOf<T0, T1, T2, T3>) obj);
+            return obj is OneOf<T0, T1, T2, T3> && Equals((OneOf<T0, T1, T2, T3>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -592,14 +821,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -608,14 +843,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -624,14 +865,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -640,14 +887,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -656,12 +909,19 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4> (T4 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>(T4 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4>(4, value4: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
@@ -750,7 +1010,25 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -760,41 +1038,89 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3, T4> && Equals((OneOf<T0, T1, T2, T3, T4>) obj);
+            return obj is OneOf<T0, T1, T2, T3, T4> && Equals((OneOf<T0, T1, T2, T3, T4>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -804,14 +1130,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -820,14 +1152,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -836,14 +1174,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -852,14 +1196,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -868,14 +1218,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T4 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T4 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -884,12 +1240,19 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T5 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T5 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(5, value5: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
@@ -991,7 +1354,27 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1001,41 +1384,97 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3, T4, T5> && Equals((OneOf<T0, T1, T2, T3, T4, T5>) obj);
+            return obj is OneOf<T0, T1, T2, T3, T4, T5> && Equals((OneOf<T0, T1, T2, T3, T4, T5>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1045,14 +1484,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1061,14 +1506,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1077,14 +1528,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1093,14 +1550,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1109,14 +1572,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T4 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T4 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1125,14 +1594,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T5 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T5 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -1141,12 +1616,19 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T6 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T6 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(6, value6: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
@@ -1261,7 +1743,29 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1271,41 +1775,105 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6>) obj);
+            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
+        where T7 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
+        readonly T7 _value7;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
+            _value7 = value7;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    case 7:
+                        return _value7;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1315,14 +1883,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1331,14 +1905,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1347,14 +1927,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1363,14 +1949,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1379,14 +1971,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T4 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T4 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1395,14 +1993,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T5 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T5 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -1411,14 +2015,20 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T6 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T6 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(6, value6: t);
         }
-
 
         public bool IsT7
         {
@@ -1427,12 +2037,19 @@ namespace OneOf
         
         public T7 AsT7
         {
-            get { return Get<T7>(7); }
+            get
+            {
+                if (_index != 7)
+                {
+                    throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
+                }
+                return _value7;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T7 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T7 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(7, value7: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
@@ -1560,7 +2177,31 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                case 7:
+                    return Equals(_value7, other._value7);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1570,41 +2211,113 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7>) obj);
+            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    case 7:
+                    hashCode = _value7?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
+        where T7 : class
+        where T8 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
+        readonly T7 _value7;
+        readonly T8 _value8;
         readonly int _index;
-        
-        OneOf(object value, int index)
-        {
-            _value = value; 
+    
+        OneOf(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
+            _value7 = value7;
+            _value8 = value8;
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    case 7:
+                        return _value7;
+                    case 8:
+                        return _value8;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1614,14 +2327,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T0 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1630,14 +2349,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T1 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1646,14 +2371,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T2 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1662,14 +2393,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T3 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1678,14 +2415,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T4 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1694,14 +2437,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T5 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -1710,14 +2459,20 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T6 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(6, value6: t);
         }
-
 
         public bool IsT7
         {
@@ -1726,14 +2481,20 @@ namespace OneOf
         
         public T7 AsT7
         {
-            get { return Get<T7>(7); }
+            get
+            {
+                if (_index != 7)
+                {
+                    throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
+                }
+                return _value7;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T7 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(7, value7: t);
         }
-
 
         public bool IsT8
         {
@@ -1742,12 +2503,19 @@ namespace OneOf
         
         public T8 AsT8
         {
-            get { return Get<T8>(8); }
+            get
+            {
+                if (_index != 8)
+                {
+                    throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
+                }
+                return _value8;
+            }
         }
         
-        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T8 t)
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 t)
         {
-             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(8, value8: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
@@ -1888,7 +2656,33 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                case 7:
+                    return Equals(_value7, other._value7);
+                case 8:
+                    return Equals(_value8, other._value8);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1898,16 +2692,49 @@ namespace OneOf
                 return false;
             }
 
-            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>) obj);
+            return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>)obj);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    case 7:
+                    hashCode = _value7?.GetHashCode() ?? 0;
+                    break;
+                    case 8:
+                    hashCode = _value8?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
-
 }

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -1,4 +1,3 @@
-
 using System;
 
 namespace OneOf
@@ -13,7 +12,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -52,7 +51,6 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
-
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
@@ -110,7 +108,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -170,7 +168,6 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
-
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
@@ -236,7 +233,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -318,7 +315,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
             if (IsT0 && f0 != null)
@@ -391,7 +387,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -494,7 +490,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
             if (IsT0 && f0 != null)
@@ -575,7 +570,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -699,7 +694,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
             if (IsT0 && f0 != null)
@@ -788,7 +782,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -933,7 +927,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
             if (IsT0 && f0 != null)
@@ -1030,7 +1023,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1196,7 +1189,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
             if (IsT0 && f0 != null)
@@ -1301,7 +1293,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1488,7 +1480,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
             if (IsT0 && f0 != null)
@@ -1601,7 +1592,7 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1808,7 +1799,6 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
-
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -5,32 +5,32 @@ namespace OneOf
 {
     public struct OneOf<T0> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -43,12 +43,11 @@ namespace OneOf
              return new OneOf<T0>(t, 0);
         }
 
-
         public void Switch(Action<T0> f0)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
             throw new InvalidOperationException();
@@ -57,18 +56,18 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
             if (otherwise != null)
             {
@@ -79,7 +78,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -96,39 +95,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -144,7 +143,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -157,17 +156,16 @@ namespace OneOf
              return new OneOf<T0, T1>(t, 1);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
             throw new InvalidOperationException();
@@ -176,26 +174,26 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
             if (otherwise != null)
             {
@@ -206,7 +204,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -223,39 +221,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -271,7 +269,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -287,7 +285,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -300,22 +298,21 @@ namespace OneOf
              return new OneOf<T0, T1, T2>(t, 2);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
             throw new InvalidOperationException();
@@ -324,34 +321,34 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
             if (otherwise != null)
             {
@@ -362,7 +359,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -379,39 +376,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -427,7 +424,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -443,7 +440,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -459,7 +456,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -472,27 +469,26 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3>(t, 3);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
             throw new InvalidOperationException();
@@ -501,42 +497,42 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
             if (otherwise != null)
             {
@@ -547,7 +543,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -564,39 +560,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -612,7 +608,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -628,7 +624,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -644,7 +640,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -660,7 +656,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -673,32 +669,31 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3, T4>(t, 4);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
             throw new InvalidOperationException();
@@ -707,50 +702,50 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
             if (otherwise != null)
             {
@@ -761,7 +756,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -778,39 +773,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -826,7 +821,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -842,7 +837,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -858,7 +853,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -874,7 +869,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -890,7 +885,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -903,37 +898,36 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3, T4, T5>(t, 5);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
             throw new InvalidOperationException();
@@ -942,58 +936,58 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
             if (otherwise != null)
             {
@@ -1004,7 +998,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1021,39 +1015,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1069,7 +1063,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1085,7 +1079,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1101,7 +1095,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1117,7 +1111,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1133,7 +1127,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1149,7 +1143,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -1162,42 +1156,41 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 6);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1206,66 +1199,66 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
             if (otherwise != null)
             {
@@ -1276,7 +1269,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1293,39 +1286,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1341,7 +1334,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1357,7 +1350,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1373,7 +1366,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1389,7 +1382,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1405,7 +1398,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1421,7 +1414,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -1437,7 +1430,7 @@ namespace OneOf
 
         public bool IsT7
         {
-            get { return index == 7; }
+            get { return _index == 7; }
         }
         
         public T7 AsT7
@@ -1450,47 +1443,46 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                f7(this.AsT7);
+                f7(AsT7);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1499,74 +1491,74 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
             if (otherwise != null)
             {
@@ -1577,7 +1569,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1594,39 +1586,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOf(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1642,7 +1634,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1658,7 +1650,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1674,7 +1666,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1690,7 +1682,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1706,7 +1698,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1722,7 +1714,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -1738,7 +1730,7 @@ namespace OneOf
 
         public bool IsT7
         {
-            get { return index == 7; }
+            get { return _index == 7; }
         }
         
         public T7 AsT7
@@ -1754,7 +1746,7 @@ namespace OneOf
 
         public bool IsT8
         {
-            get { return index == 8; }
+            get { return _index == 8; }
         }
         
         public T8 AsT8
@@ -1767,52 +1759,51 @@ namespace OneOf
              return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                f7(this.AsT7);
+                f7(AsT7);
                 return; 
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                f8(this.AsT8);
+                f8(AsT8);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1821,82 +1812,82 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                return f8(this.AsT8);
+                return f8(AsT8);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                return f8(this.AsT8);
+                return f8(AsT8);
             }
             if (otherwise != null)
             {
@@ -1907,7 +1898,7 @@ namespace OneOf
 
         bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1924,7 +1915,7 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -3,66 +3,81 @@ using System;
 
 namespace OneOf
 {
-	
-
-	public struct OneOf<T0> : IOneOf
+    public struct OneOf<T0> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0> (T0 t)
         {
-	         return new OneOf<T0>(t, 0);
+             return new OneOf<T0>(t, 0);
         }
 
 
-	    public void Switch(Action<T0> f0)
+        public void Switch(Action<T0> f0)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0)
+        public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0> other)
+        bool Equals(OneOf<T0> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -84,79 +99,112 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1> : IOneOf
+    public struct OneOf<T0, T1> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1> (T0 t)
         {
-	         return new OneOf<T0, T1>(t, 0);
+             return new OneOf<T0, T1>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1> (T1 t)
         {
-	         return new OneOf<T0, T1>(t, 1);
+             return new OneOf<T0, T1>(t, 1);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1)
+        public void Switch(Action<T0> f0, Action<T1> f1)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1> other)
+        bool Equals(OneOf<T0, T1> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -178,91 +226,141 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2> : IOneOf
+    public struct OneOf<T0, T1, T2> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2> (T0 t)
         {
-	         return new OneOf<T0, T1, T2>(t, 0);
+             return new OneOf<T0, T1, T2>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2> (T1 t)
         {
-	         return new OneOf<T0, T1, T2>(t, 1);
+             return new OneOf<T0, T1, T2>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2> (T2 t)
         {
-	         return new OneOf<T0, T1, T2>(t, 2);
+             return new OneOf<T0, T1, T2>(t, 2);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2> other)
+        bool Equals(OneOf<T0, T1, T2> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -284,103 +382,170 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3> : IOneOf
+    public struct OneOf<T0, T1, T2, T3> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3>(t, 0);
+             return new OneOf<T0, T1, T2, T3>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3>(t, 1);
+             return new OneOf<T0, T1, T2, T3>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3>(t, 2);
+             return new OneOf<T0, T1, T2, T3>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3>(t, 3);
+             return new OneOf<T0, T1, T2, T3>(t, 3);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3> other)
+        bool Equals(OneOf<T0, T1, T2, T3> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -402,115 +567,199 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
+    public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4> (T4 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4>(t, 4);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3, T4> other)
+        bool Equals(OneOf<T0, T1, T2, T3, T4> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -532,127 +781,228 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
+    public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T4 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5> (T5 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5>(t, 5);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other)
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -674,139 +1024,257 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
+    public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T4 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T5 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6> (T6 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6>(t, 6);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other)
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -828,151 +1296,286 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
+    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T4 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T5 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T6 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
         }
 
 
-        public bool IsT7 { get { return index == 7; } }
-        public T7 AsT7 { get { return Get<T7>(7); } } 
+        public bool IsT7
+        {
+            get { return index == 7; }
+        }
+        
+        public T7 AsT7
+        {
+            get { return Get<T7>(7); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7> (T7 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
-			if (this.IsT7 && f7 != null) { f7(this.AsT7); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                f7(this.AsT7);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other)
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -994,163 +1597,315 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOf(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOf(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T0 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T1 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T2 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T3 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T4 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T5 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T6 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
         }
 
 
-        public bool IsT7 { get { return index == 7; } }
-        public T7 AsT7 { get { return Get<T7>(7); } } 
+        public bool IsT7
+        {
+            get { return index == 7; }
+        }
+        
+        public T7 AsT7
+        {
+            get { return Get<T7>(7); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T7 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
         }
 
 
-        public bool IsT8 { get { return index == 8; } }
-        public T8 AsT8 { get { return Get<T8>(8); } } 
+        public bool IsT8
+        {
+            get { return index == 8; }
+        }
+        
+        public T8 AsT8
+        {
+            get { return Get<T8>(8); }
+        }
+        
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T8 t)
         {
-	         return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
+             return new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
-			if (this.IsT7 && f7 != null) { f7(this.AsT7); return; }
-			if (this.IsT8 && f8 != null) { f8(this.AsT8); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                f7(this.AsT7);
+                return; 
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                f8(this.AsT8);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
-			if (this.IsT8 && f8 != null) return f8(this.AsT8);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                return f8(this.AsT8);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                return f8(this.AsT8);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
-
-			if (this.IsT8 && f8 != null) return f8(this.AsT8);
-
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
-
-
-		
-		bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -1172,6 +1927,6 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
 }

--- a/OneOf/OneOf.xproj
+++ b/OneOf/OneOf.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>21d0dd1e-d38a-4a76-b2b3-4cef11b2c6cb</ProjectGuid>
     <RootNamespace>OneOf</RootNamespace>
@@ -15,5 +15,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -3,38 +3,42 @@ using System;
 namespace OneOf
 {
     public class OneOfBase<T0> : IOneOf
+        where T0 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0))
+        { 
             _index = index;
+            _value0 = value0;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -44,12 +48,19 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0> (T0 t)
+        public static implicit operator OneOfBase<T0>(T0 t)
         {
-             return new OneOfBase<T0>(t, 0);
+             return new OneOfBase<T0>(0, value0: t);
         }
 
         public void Switch(Action<T0> f0)
@@ -86,7 +97,17 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -109,49 +130,72 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1> : IOneOf
+        where T0 : class
+        where T1 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -161,14 +205,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1> (T0 t)
+        public static implicit operator OneOfBase<T0, T1>(T0 t)
         {
-             return new OneOfBase<T0, T1>(t, 0);
+             return new OneOfBase<T0, T1>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -177,12 +227,19 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1> (T1 t)
+        public static implicit operator OneOfBase<T0, T1>(T1 t)
         {
-             return new OneOfBase<T0, T1>(t, 1);
+             return new OneOfBase<T0, T1>(1, value1: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1)
@@ -232,7 +289,19 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -255,54 +324,89 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -312,14 +416,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2>(t, 0);
+             return new OneOfBase<T0, T1, T2>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -328,14 +438,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2>(t, 1);
+             return new OneOfBase<T0, T1, T2>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -344,12 +460,19 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2>(t, 2);
+             return new OneOfBase<T0, T1, T2>(2, value2: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
@@ -412,7 +535,21 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -435,59 +572,106 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -497,14 +681,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -513,14 +703,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -529,14 +725,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -545,12 +747,19 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3>(3, value3: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
@@ -626,7 +835,23 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -649,64 +874,123 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
-
-            if (this is T4)
             {
-                _index = 4;
+                var value = this as T4;
+                if (value != null)
+                {
+                    _index = 4;
+                    _value4 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -716,14 +1000,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -732,14 +1022,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -748,14 +1044,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -764,14 +1066,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -780,12 +1088,19 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T4 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T4 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4>(4, value4: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
@@ -874,7 +1189,25 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -897,69 +1230,140 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
-
-            if (this is T4)
             {
-                _index = 4;
+                var value = this as T4;
+                if (value != null)
+                {
+                    _index = 4;
+                    _value4 = value;
+                    return;
+                }
             }
-
-            if (this is T5)
             {
-                _index = 5;
+                var value = this as T5;
+                if (value != null)
+                {
+                    _index = 5;
+                    _value5 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -969,14 +1373,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -985,14 +1395,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1001,14 +1417,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1017,14 +1439,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1033,14 +1461,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T4 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T4 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1049,12 +1483,19 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T5 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T5 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(5, value5: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
@@ -1156,7 +1597,27 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1179,74 +1640,157 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
-
-            if (this is T4)
             {
-                _index = 4;
+                var value = this as T4;
+                if (value != null)
+                {
+                    _index = 4;
+                    _value4 = value;
+                    return;
+                }
             }
-
-            if (this is T5)
             {
-                _index = 5;
+                var value = this as T5;
+                if (value != null)
+                {
+                    _index = 5;
+                    _value5 = value;
+                    return;
+                }
             }
-
-            if (this is T6)
             {
-                _index = 6;
+                var value = this as T6;
+                if (value != null)
+                {
+                    _index = 6;
+                    _value6 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1256,14 +1800,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1272,14 +1822,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1288,14 +1844,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1304,14 +1866,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1320,14 +1888,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T4 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T4 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1336,14 +1910,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T5 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T5 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -1352,12 +1932,19 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T6 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T6 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(6, value6: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
@@ -1472,7 +2059,29 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1495,79 +2104,174 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
+        where T7 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
+        readonly T7 _value7;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
+            _value7 = value7;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
-
-            if (this is T4)
             {
-                _index = 4;
+                var value = this as T4;
+                if (value != null)
+                {
+                    _index = 4;
+                    _value4 = value;
+                    return;
+                }
             }
-
-            if (this is T5)
             {
-                _index = 5;
+                var value = this as T5;
+                if (value != null)
+                {
+                    _index = 5;
+                    _value5 = value;
+                    return;
+                }
             }
-
-            if (this is T6)
             {
-                _index = 6;
+                var value = this as T6;
+                if (value != null)
+                {
+                    _index = 6;
+                    _value6 = value;
+                    return;
+                }
             }
-
-            if (this is T7)
             {
-                _index = 7;
+                var value = this as T7;
+                if (value != null)
+                {
+                    _index = 7;
+                    _value7 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    case 7:
+                        return _value7;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1577,14 +2281,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1593,14 +2303,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1609,14 +2325,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1625,14 +2347,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1641,14 +2369,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T4 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T4 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -1657,14 +2391,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T5 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T5 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -1673,14 +2413,20 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T6 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T6 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(6, value6: t);
         }
-
 
         public bool IsT7
         {
@@ -1689,12 +2435,19 @@ namespace OneOf
         
         public T7 AsT7
         {
-            get { return Get<T7>(7); }
+            get
+            {
+                if (_index != 7)
+                {
+                    throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
+                }
+                return _value7;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T7 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T7 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(7, value7: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
@@ -1822,7 +2575,31 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                case 7:
+                    return Equals(_value7, other._value7);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -1845,84 +2622,191 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    case 7:
+                    hashCode = _value7?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+        where T0 : class
+        where T1 : class
+        where T2 : class
+        where T3 : class
+        where T4 : class
+        where T5 : class
+        where T6 : class
+        where T7 : class
+        where T8 : class
     {
-        readonly object _value;
+        readonly T0 _value0;
+        readonly T1 _value1;
+        readonly T2 _value2;
+        readonly T3 _value3;
+        readonly T4 _value4;
+        readonly T5 _value5;
+        readonly T6 _value6;
+        readonly T7 _value7;
+        readonly T8 _value8;
         readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
+    
+        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8))
+        { 
             _index = index;
+            _value0 = value0;
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
+            _value7 = value7;
+            _value8 = value8;
         }
 
-        protected OneOfBase()
+            protected OneOfBase()
         {
-            _value = this;
-
-            if (this is T0)
             {
-                _index = 0;
+                var value = this as T0;
+                if (value != null)
+                {
+                    _index = 0;
+                    _value0 = value;
+                    return;
+                }
             }
-
-            if (this is T1)
             {
-                _index = 1;
+                var value = this as T1;
+                if (value != null)
+                {
+                    _index = 1;
+                    _value1 = value;
+                    return;
+                }
             }
-
-            if (this is T2)
             {
-                _index = 2;
+                var value = this as T2;
+                if (value != null)
+                {
+                    _index = 2;
+                    _value2 = value;
+                    return;
+                }
             }
-
-            if (this is T3)
             {
-                _index = 3;
+                var value = this as T3;
+                if (value != null)
+                {
+                    _index = 3;
+                    _value3 = value;
+                    return;
+                }
             }
-
-            if (this is T4)
             {
-                _index = 4;
+                var value = this as T4;
+                if (value != null)
+                {
+                    _index = 4;
+                    _value4 = value;
+                    return;
+                }
             }
-
-            if (this is T5)
             {
-                _index = 5;
+                var value = this as T5;
+                if (value != null)
+                {
+                    _index = 5;
+                    _value5 = value;
+                    return;
+                }
             }
-
-            if (this is T6)
             {
-                _index = 6;
+                var value = this as T6;
+                if (value != null)
+                {
+                    _index = 6;
+                    _value6 = value;
+                    return;
+                }
             }
-
-            if (this is T7)
             {
-                _index = 7;
+                var value = this as T7;
+                if (value != null)
+                {
+                    _index = 7;
+                    _value7 = value;
+                    return;
+                }
             }
-
-            if (this is T8)
             {
-                _index = 8;
+                var value = this as T8;
+                if (value != null)
+                {
+                    _index = 8;
+                    _value8 = value;
+                    return;
+                }
             }
         }
 
         object IOneOf.Value 
         {
-            get { return _value; }
-        }
-    
-        T Get<T>(int index)
-        {
-            if (index != _index)
+            get
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
+                switch (_index)
+                {
+                    case 0:
+                        return _value0;
+                    case 1:
+                        return _value1;
+                    case 2:
+                        return _value2;
+                    case 3:
+                        return _value3;
+                    case 4:
+                        return _value4;
+                    case 5:
+                        return _value5;
+                    case 6:
+                        return _value6;
+                    case 7:
+                        return _value7;
+                    case 8:
+                        return _value8;
+                    default:
+                        throw new InvalidOperationException();
+                }
             }
-            return (T)_value;
         }
 
         public bool IsT0
@@ -1932,14 +2816,20 @@ namespace OneOf
         
         public T0 AsT0
         {
-            get { return Get<T0>(0); }
+            get
+            {
+                if (_index != 0)
+                {
+                    throw new InvalidOperationException($"Cannot return as T0 as result is T{_index}");
+                }
+                return _value0;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T0 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(0, value0: t);
         }
-
 
         public bool IsT1
         {
@@ -1948,14 +2838,20 @@ namespace OneOf
         
         public T1 AsT1
         {
-            get { return Get<T1>(1); }
+            get
+            {
+                if (_index != 1)
+                {
+                    throw new InvalidOperationException($"Cannot return as T1 as result is T{_index}");
+                }
+                return _value1;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T1 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(1, value1: t);
         }
-
 
         public bool IsT2
         {
@@ -1964,14 +2860,20 @@ namespace OneOf
         
         public T2 AsT2
         {
-            get { return Get<T2>(2); }
+            get
+            {
+                if (_index != 2)
+                {
+                    throw new InvalidOperationException($"Cannot return as T2 as result is T{_index}");
+                }
+                return _value2;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T2 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(2, value2: t);
         }
-
 
         public bool IsT3
         {
@@ -1980,14 +2882,20 @@ namespace OneOf
         
         public T3 AsT3
         {
-            get { return Get<T3>(3); }
+            get
+            {
+                if (_index != 3)
+                {
+                    throw new InvalidOperationException($"Cannot return as T3 as result is T{_index}");
+                }
+                return _value3;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T3 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(3, value3: t);
         }
-
 
         public bool IsT4
         {
@@ -1996,14 +2904,20 @@ namespace OneOf
         
         public T4 AsT4
         {
-            get { return Get<T4>(4); }
+            get
+            {
+                if (_index != 4)
+                {
+                    throw new InvalidOperationException($"Cannot return as T4 as result is T{_index}");
+                }
+                return _value4;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T4 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(4, value4: t);
         }
-
 
         public bool IsT5
         {
@@ -2012,14 +2926,20 @@ namespace OneOf
         
         public T5 AsT5
         {
-            get { return Get<T5>(5); }
+            get
+            {
+                if (_index != 5)
+                {
+                    throw new InvalidOperationException($"Cannot return as T5 as result is T{_index}");
+                }
+                return _value5;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T5 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(5, value5: t);
         }
-
 
         public bool IsT6
         {
@@ -2028,14 +2948,20 @@ namespace OneOf
         
         public T6 AsT6
         {
-            get { return Get<T6>(6); }
+            get
+            {
+                if (_index != 6)
+                {
+                    throw new InvalidOperationException($"Cannot return as T6 as result is T{_index}");
+                }
+                return _value6;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T6 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(6, value6: t);
         }
-
 
         public bool IsT7
         {
@@ -2044,14 +2970,20 @@ namespace OneOf
         
         public T7 AsT7
         {
-            get { return Get<T7>(7); }
+            get
+            {
+                if (_index != 7)
+                {
+                    throw new InvalidOperationException($"Cannot return as T7 as result is T{_index}");
+                }
+                return _value7;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T7 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(7, value7: t);
         }
-
 
         public bool IsT8
         {
@@ -2060,12 +2992,19 @@ namespace OneOf
         
         public T8 AsT8
         {
-            get { return Get<T8>(8); }
+            get
+            {
+                if (_index != 8)
+                {
+                    throw new InvalidOperationException($"Cannot return as T8 as result is T{_index}");
+                }
+                return _value8;
+            }
         }
         
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T8 t)
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 t)
         {
-             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(8, value8: t);
         }
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
@@ -2206,7 +3145,33 @@ namespace OneOf
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
-            return _index == other._index && Equals(_value, other._value);
+            if (_index != other._index)
+            {
+                return false;
+            }
+            switch (_index)
+            {
+                case 0:
+                    return Equals(_value0, other._value0);
+                case 1:
+                    return Equals(_value1, other._value1);
+                case 2:
+                    return Equals(_value2, other._value2);
+                case 3:
+                    return Equals(_value3, other._value3);
+                case 4:
+                    return Equals(_value4, other._value4);
+                case 5:
+                    return Equals(_value5, other._value5);
+                case 6:
+                    return Equals(_value6, other._value6);
+                case 7:
+                    return Equals(_value7, other._value7);
+                case 8:
+                    return Equals(_value8, other._value8);
+                default:
+                    return false;
+            }
         }
 
         public override bool Equals(object obj)
@@ -2229,9 +3194,42 @@ namespace OneOf
         {
             unchecked
             {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                int hashCode;
+                switch (_index)
+                {
+                    case 0:
+                    hashCode = _value0?.GetHashCode() ?? 0;
+                    break;
+                    case 1:
+                    hashCode = _value1?.GetHashCode() ?? 0;
+                    break;
+                    case 2:
+                    hashCode = _value2?.GetHashCode() ?? 0;
+                    break;
+                    case 3:
+                    hashCode = _value3?.GetHashCode() ?? 0;
+                    break;
+                    case 4:
+                    hashCode = _value4?.GetHashCode() ?? 0;
+                    break;
+                    case 5:
+                    hashCode = _value5?.GetHashCode() ?? 0;
+                    break;
+                    case 6:
+                    hashCode = _value6?.GetHashCode() ?? 0;
+                    break;
+                    case 7:
+                    hashCode = _value7?.GetHashCode() ?? 0;
+                    break;
+                    case 8:
+                    hashCode = _value8?.GetHashCode() ?? 0;
+                    break;
+                    default:
+                        hashCode = 0;
+                        break;
+                }
+                return (hashCode*397) ^ _index;
             }
         }
     }
-
 }

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -3,27 +3,23 @@ using System;
 namespace OneOf
 {
     public class OneOfBase<T0> : IOneOf
-        where T0 : class
     {
         readonly T0 _value0;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0))
+        protected OneOfBase(int index, T0 value0 = default(T0))
         { 
             _index = index;
             _value0 = value0;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
         }
 
@@ -146,39 +142,31 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1> : IOneOf
-        where T0 : class
-        where T1 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1))
         { 
             _index = index;
             _value0 = value0;
             _value1 = value1;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
         }
 
@@ -343,16 +331,13 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
         readonly T2 _value2;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2))
         { 
             _index = index;
             _value0 = value0;
@@ -360,34 +345,25 @@ namespace OneOf
             _value2 = value2;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
         }
 
@@ -594,10 +570,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -605,7 +577,7 @@ namespace OneOf
         readonly T3 _value3;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3))
         { 
             _index = index;
             _value0 = value0;
@@ -614,43 +586,31 @@ namespace OneOf
             _value3 = value3;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
         }
 
@@ -899,11 +859,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -912,7 +867,7 @@ namespace OneOf
         readonly T4 _value4;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4))
         { 
             _index = index;
             _value0 = value0;
@@ -922,52 +877,37 @@ namespace OneOf
             _value4 = value4;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
+            if (this is T4)
             {
-                var value = this as T4;
-                if (value != null)
-                {
-                    _index = 4;
-                    _value4 = value;
-                    return;
-                }
+                _index = 4;
+                _value4 = (T4)(object)this;
+                return;
             }
         }
 
@@ -1258,12 +1198,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -1273,7 +1207,7 @@ namespace OneOf
         readonly T5 _value5;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5))
         { 
             _index = index;
             _value0 = value0;
@@ -1284,61 +1218,43 @@ namespace OneOf
             _value5 = value5;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
+            if (this is T4)
             {
-                var value = this as T4;
-                if (value != null)
-                {
-                    _index = 4;
-                    _value4 = value;
-                    return;
-                }
+                _index = 4;
+                _value4 = (T4)(object)this;
+                return;
             }
+            if (this is T5)
             {
-                var value = this as T5;
-                if (value != null)
-                {
-                    _index = 5;
-                    _value5 = value;
-                    return;
-                }
+                _index = 5;
+                _value5 = (T5)(object)this;
+                return;
             }
         }
 
@@ -1671,13 +1587,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -1688,7 +1597,7 @@ namespace OneOf
         readonly T6 _value6;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6))
         { 
             _index = index;
             _value0 = value0;
@@ -1700,70 +1609,49 @@ namespace OneOf
             _value6 = value6;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
+            if (this is T4)
             {
-                var value = this as T4;
-                if (value != null)
-                {
-                    _index = 4;
-                    _value4 = value;
-                    return;
-                }
+                _index = 4;
+                _value4 = (T4)(object)this;
+                return;
             }
+            if (this is T5)
             {
-                var value = this as T5;
-                if (value != null)
-                {
-                    _index = 5;
-                    _value5 = value;
-                    return;
-                }
+                _index = 5;
+                _value5 = (T5)(object)this;
+                return;
             }
+            if (this is T6)
             {
-                var value = this as T6;
-                if (value != null)
-                {
-                    _index = 6;
-                    _value6 = value;
-                    return;
-                }
+                _index = 6;
+                _value6 = (T6)(object)this;
+                return;
             }
         }
 
@@ -2138,14 +2026,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
-        where T7 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -2157,7 +2037,7 @@ namespace OneOf
         readonly T7 _value7;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7))
         { 
             _index = index;
             _value0 = value0;
@@ -2170,79 +2050,55 @@ namespace OneOf
             _value7 = value7;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
+            if (this is T4)
             {
-                var value = this as T4;
-                if (value != null)
-                {
-                    _index = 4;
-                    _value4 = value;
-                    return;
-                }
+                _index = 4;
+                _value4 = (T4)(object)this;
+                return;
             }
+            if (this is T5)
             {
-                var value = this as T5;
-                if (value != null)
-                {
-                    _index = 5;
-                    _value5 = value;
-                    return;
-                }
+                _index = 5;
+                _value5 = (T5)(object)this;
+                return;
             }
+            if (this is T6)
             {
-                var value = this as T6;
-                if (value != null)
-                {
-                    _index = 6;
-                    _value6 = value;
-                    return;
-                }
+                _index = 6;
+                _value6 = (T6)(object)this;
+                return;
             }
+            if (this is T7)
             {
-                var value = this as T7;
-                if (value != null)
-                {
-                    _index = 7;
-                    _value7 = value;
-                    return;
-                }
+                _index = 7;
+                _value7 = (T7)(object)this;
+                return;
             }
         }
 
@@ -2659,15 +2515,6 @@ namespace OneOf
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
-        where T0 : class
-        where T1 : class
-        where T2 : class
-        where T3 : class
-        where T4 : class
-        where T5 : class
-        where T6 : class
-        where T7 : class
-        where T8 : class
     {
         readonly T0 _value0;
         readonly T1 _value1;
@@ -2680,7 +2527,7 @@ namespace OneOf
         readonly T8 _value8;
         readonly int _index;
     
-        OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8))
+        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8))
         { 
             _index = index;
             _value0 = value0;
@@ -2694,88 +2541,61 @@ namespace OneOf
             _value8 = value8;
         }
 
-            protected OneOfBase()
+        protected OneOfBase()
         {
+            if (this is T0)
             {
-                var value = this as T0;
-                if (value != null)
-                {
-                    _index = 0;
-                    _value0 = value;
-                    return;
-                }
+                _index = 0;
+                _value0 = (T0)(object)this;
+                return;
             }
+            if (this is T1)
             {
-                var value = this as T1;
-                if (value != null)
-                {
-                    _index = 1;
-                    _value1 = value;
-                    return;
-                }
+                _index = 1;
+                _value1 = (T1)(object)this;
+                return;
             }
+            if (this is T2)
             {
-                var value = this as T2;
-                if (value != null)
-                {
-                    _index = 2;
-                    _value2 = value;
-                    return;
-                }
+                _index = 2;
+                _value2 = (T2)(object)this;
+                return;
             }
+            if (this is T3)
             {
-                var value = this as T3;
-                if (value != null)
-                {
-                    _index = 3;
-                    _value3 = value;
-                    return;
-                }
+                _index = 3;
+                _value3 = (T3)(object)this;
+                return;
             }
+            if (this is T4)
             {
-                var value = this as T4;
-                if (value != null)
-                {
-                    _index = 4;
-                    _value4 = value;
-                    return;
-                }
+                _index = 4;
+                _value4 = (T4)(object)this;
+                return;
             }
+            if (this is T5)
             {
-                var value = this as T5;
-                if (value != null)
-                {
-                    _index = 5;
-                    _value5 = value;
-                    return;
-                }
+                _index = 5;
+                _value5 = (T5)(object)this;
+                return;
             }
+            if (this is T6)
             {
-                var value = this as T6;
-                if (value != null)
-                {
-                    _index = 6;
-                    _value6 = value;
-                    return;
-                }
+                _index = 6;
+                _value6 = (T6)(object)this;
+                return;
             }
+            if (this is T7)
             {
-                var value = this as T7;
-                if (value != null)
-                {
-                    _index = 7;
-                    _value7 = value;
-                    return;
-                }
+                _index = 7;
+                _value7 = (T7)(object)this;
+                return;
             }
+            if (this is T8)
             {
-                var value = this as T8;
-                if (value != null)
-                {
-                    _index = 8;
-                    _value8 = value;
-                    return;
-                }
+                _index = 8;
+                _value8 = (T8)(object)this;
+                return;
             }
         }
 

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -3,75 +3,91 @@ using System;
 
 namespace OneOf
 {
-	
-
-	public class OneOfBase<T0> : IOneOf
+    public class OneOfBase<T0> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0> (T0 t)
         {
-	         return new OneOfBase<T0>(t, 0);
+             return new OneOfBase<T0>(t, 0);
         }
 
 
-	    public void Switch(Action<T0> f0)
+        public void Switch(Action<T0> f0)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0)
+        public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T0)
+            {
+                this.index = 0;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0> other)
+        bool Equals(OneOfBase<T0> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -99,90 +115,127 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1> : IOneOf
+    public class OneOfBase<T0, T1> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1> (T0 t)
         {
-	         return new OneOfBase<T0, T1>(t, 0);
+             return new OneOfBase<T0, T1>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1> (T1 t)
         {
-	         return new OneOfBase<T0, T1>(t, 1);
+             return new OneOfBase<T0, T1>(t, 1);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1)
+        public void Switch(Action<T0> f0, Action<T1> f1)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T1)
+            {
+                this.index = 1;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1> other)
+        bool Equals(OneOfBase<T0, T1> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -210,104 +263,161 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2> : IOneOf
+    public class OneOfBase<T0, T1, T2> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2>(t, 0);
+             return new OneOfBase<T0, T1, T2>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2>(t, 1);
+             return new OneOfBase<T0, T1, T2>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2>(t, 2);
+             return new OneOfBase<T0, T1, T2>(t, 2);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T2)
+            {
+                this.index = 2;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2> other)
+        bool Equals(OneOfBase<T0, T1, T2> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -335,118 +445,195 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3>(t, 3);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T3)
+            {
+                this.index = 3;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -474,132 +661,229 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4> (T4 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4>(t, 4);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this is T3)
+            {
+                this.index = 3;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T4)
+            {
+                this.index = 4;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-			if (this is T4) this.index = 4;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3, T4> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -627,146 +911,263 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T4 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5> (T5 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 5);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this is T3)
+            {
+                this.index = 3;
+            }
 
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this is T4)
+            {
+                this.index = 4;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T5)
+            {
+                this.index = 5;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-			if (this is T4) this.index = 4;
-
-			if (this is T5) this.index = 5;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -794,160 +1195,297 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T4 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T5 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6> (T6 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 6);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this is T3)
+            {
+                this.index = 3;
+            }
 
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this is T4)
+            {
+                this.index = 4;
+            }
 
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
+            if (this is T5)
+            {
+                this.index = 5;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T6)
+            {
+                this.index = 6;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-			if (this is T4) this.index = 4;
-
-			if (this is T5) this.index = 5;
-
-			if (this is T6) this.index = 6;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -975,174 +1513,331 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T4 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T5 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T6 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 6);
         }
 
 
-        public bool IsT7 { get { return index == 7; } }
-        public T7 AsT7 { get { return Get<T7>(7); } } 
+        public bool IsT7
+        {
+            get { return index == 7; }
+        }
+        
+        public T7 AsT7
+        {
+            get { return Get<T7>(7); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> (T7 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
-			if (this.IsT7 && f7 != null) { f7(this.AsT7); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                f7(this.AsT7);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this is T3)
+            {
+                this.index = 3;
+            }
 
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this is T4)
+            {
+                this.index = 4;
+            }
 
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
+            if (this is T5)
+            {
+                this.index = 5;
+            }
 
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
+            if (this is T6)
+            {
+                this.index = 6;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T7)
+            {
+                this.index = 7;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-			if (this is T4) this.index = 4;
-
-			if (this is T5) this.index = 5;
-
-			if (this is T6) this.index = 6;
-
-			if (this is T7) this.index = 7;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -1170,188 +1865,365 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
-
-	public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+    public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-	    readonly object value;
-	    readonly int index;
-	    
-		OneOfBase(object value, int index)	    { this.value = value; this.index = index;	     }
-	
-		object IOneOf.Value { get { return value; } }
-	
-	    T Get<T>(int index)
-	    {
-		    if (index != this.index)
-		    {
-		    	throw new InvalidOperationException("Cannot return as T" + index + " as result is T" + this.index);
+        readonly object value;
+        readonly int index;
+        
+        OneOfBase(object value, int index)
+        {
+            this.value = value; 
+            this.index = index;
+        }
+    
+        object IOneOf.Value 
+        {
+            get { return value; }
+        }
+    
+        T Get<T>(int index)
+        {
+            if (index != this.index)
+            {
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
             }
-	        return (T)value;
-	    }
+            return (T)value;
+        }
 
-
-        public bool IsT0 { get { return index == 0; } }
-        public T0 AsT0 { get { return Get<T0>(0); } } 
+        public bool IsT0
+        {
+            get { return index == 0; }
+        }
+        
+        public T0 AsT0
+        {
+            get { return Get<T0>(0); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T0 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 0);
         }
 
 
-        public bool IsT1 { get { return index == 1; } }
-        public T1 AsT1 { get { return Get<T1>(1); } } 
+        public bool IsT1
+        {
+            get { return index == 1; }
+        }
+        
+        public T1 AsT1
+        {
+            get { return Get<T1>(1); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T1 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 1);
         }
 
 
-        public bool IsT2 { get { return index == 2; } }
-        public T2 AsT2 { get { return Get<T2>(2); } } 
+        public bool IsT2
+        {
+            get { return index == 2; }
+        }
+        
+        public T2 AsT2
+        {
+            get { return Get<T2>(2); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T2 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 2);
         }
 
 
-        public bool IsT3 { get { return index == 3; } }
-        public T3 AsT3 { get { return Get<T3>(3); } } 
+        public bool IsT3
+        {
+            get { return index == 3; }
+        }
+        
+        public T3 AsT3
+        {
+            get { return Get<T3>(3); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T3 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 3);
         }
 
 
-        public bool IsT4 { get { return index == 4; } }
-        public T4 AsT4 { get { return Get<T4>(4); } } 
+        public bool IsT4
+        {
+            get { return index == 4; }
+        }
+        
+        public T4 AsT4
+        {
+            get { return Get<T4>(4); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T4 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 4);
         }
 
 
-        public bool IsT5 { get { return index == 5; } }
-        public T5 AsT5 { get { return Get<T5>(5); } } 
+        public bool IsT5
+        {
+            get { return index == 5; }
+        }
+        
+        public T5 AsT5
+        {
+            get { return Get<T5>(5); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T5 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 5);
         }
 
 
-        public bool IsT6 { get { return index == 6; } }
-        public T6 AsT6 { get { return Get<T6>(6); } } 
+        public bool IsT6
+        {
+            get { return index == 6; }
+        }
+        
+        public T6 AsT6
+        {
+            get { return Get<T6>(6); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T6 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 6);
         }
 
 
-        public bool IsT7 { get { return index == 7; } }
-        public T7 AsT7 { get { return Get<T7>(7); } } 
+        public bool IsT7
+        {
+            get { return index == 7; }
+        }
+        
+        public T7 AsT7
+        {
+            get { return Get<T7>(7); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T7 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 7);
         }
 
 
-        public bool IsT8 { get { return index == 8; } }
-        public T8 AsT8 { get { return Get<T8>(8); } } 
+        public bool IsT8
+        {
+            get { return index == 8; }
+        }
+        
+        public T8 AsT8
+        {
+            get { return Get<T8>(8); }
+        }
+        
         public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> (T8 t)
         {
-	         return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
+             return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
         }
 
 
-	    public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
+        public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-			
-			if (this.IsT0 && f0 != null) { f0(this.AsT0); return; }
-			if (this.IsT1 && f1 != null) { f1(this.AsT1); return; }
-			if (this.IsT2 && f2 != null) { f2(this.AsT2); return; }
-			if (this.IsT3 && f3 != null) { f3(this.AsT3); return; }
-			if (this.IsT4 && f4 != null) { f4(this.AsT4); return; }
-			if (this.IsT5 && f5 != null) { f5(this.AsT5); return; }
-			if (this.IsT6 && f6 != null) { f6(this.AsT6); return; }
-			if (this.IsT7 && f7 != null) { f7(this.AsT7); return; }
-			if (this.IsT8 && f8 != null) { f8(this.AsT8); return; }
+            if (this.IsT0 && f0 != null)
+            {
+                f0(this.AsT0);
+                return; 
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                f1(this.AsT1);
+                return; 
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                f2(this.AsT2);
+                return; 
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                f3(this.AsT3);
+                return; 
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                f4(this.AsT4);
+                return; 
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                f5(this.AsT5);
+                return; 
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                f6(this.AsT6);
+                return; 
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                f7(this.AsT7);
+                return; 
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                f8(this.AsT8);
+                return; 
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
 
-
-	    public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
+        public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-			
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
-			if (this.IsT8 && f8 != null) return f8(this.AsT8);
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                return f8(this.AsT8);
+            }
+            throw new InvalidOperationException();
+        }
 
-	    	throw new InvalidOperationException();
-		}
-
-
-	    public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
+        public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-			
+            if (this.IsT0 && f0 != null)
+            {
+                return f0(this.AsT0);
+            }
+            if (this.IsT1 && f1 != null)
+            {
+                return f1(this.AsT1);
+            }
+            if (this.IsT2 && f2 != null)
+            {
+                return f2(this.AsT2);
+            }
+            if (this.IsT3 && f3 != null)
+            {
+                return f3(this.AsT3);
+            }
+            if (this.IsT4 && f4 != null)
+            {
+                return f4(this.AsT4);
+            }
+            if (this.IsT5 && f5 != null)
+            {
+                return f5(this.AsT5);
+            }
+            if (this.IsT6 && f6 != null)
+            {
+                return f6(this.AsT6);
+            }
+            if (this.IsT7 && f7 != null)
+            {
+                return f7(this.AsT7);
+            }
+            if (this.IsT8 && f8 != null)
+            {
+                return f8(this.AsT8);
+            }
+            if (otherwise != null)
+            {
+                return otherwise();
+            }
+            throw new InvalidOperationException();
+        }
 
-			if (this.IsT0 && f0 != null) return f0(this.AsT0);
+        protected OneOfBase()
+        {
+            this.value = this;
 
-			if (this.IsT1 && f1 != null) return f1(this.AsT1);
+            if (this is T0)
+            {
+                this.index = 0;
+            }
 
-			if (this.IsT2 && f2 != null) return f2(this.AsT2);
+            if (this is T1)
+            {
+                this.index = 1;
+            }
 
-			if (this.IsT3 && f3 != null) return f3(this.AsT3);
+            if (this is T2)
+            {
+                this.index = 2;
+            }
 
-			if (this.IsT4 && f4 != null) return f4(this.AsT4);
+            if (this is T3)
+            {
+                this.index = 3;
+            }
 
-			if (this.IsT5 && f5 != null) return f5(this.AsT5);
+            if (this is T4)
+            {
+                this.index = 4;
+            }
 
-			if (this.IsT6 && f6 != null) return f6(this.AsT6);
+            if (this is T5)
+            {
+                this.index = 5;
+            }
 
-			if (this.IsT7 && f7 != null) return f7(this.AsT7);
+            if (this is T6)
+            {
+                this.index = 6;
+            }
 
-			if (this.IsT8 && f8 != null) return f8(this.AsT8);
+            if (this is T7)
+            {
+                this.index = 7;
+            }
 
-		    if (otherwise != null) return otherwise();
-	    	throw new InvalidOperationException();
-		}
+            if (this is T8)
+            {
+                this.index = 8;
+            }
+        }
 
-
-		
-		protected OneOfBase()
-		{
-			this.value = this;
-
-			if (this is T0) this.index = 0;
-
-			if (this is T1) this.index = 1;
-
-			if (this is T2) this.index = 2;
-
-			if (this is T3) this.index = 3;
-
-			if (this is T4) this.index = 4;
-
-			if (this is T5) this.index = 5;
-
-			if (this is T6) this.index = 6;
-
-			if (this is T7) this.index = 7;
-
-			if (this is T8) this.index = 8;
-
-		}
-
-		
-		bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
             return index == other.index && Equals(value, other.value);
         }
@@ -1379,6 +2251,6 @@ namespace OneOf
                 return ((value?.GetHashCode() ?? 0)*397) ^ index;
             }
         }
-}
+    }
 
 }

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -65,9 +65,9 @@ namespace OneOf
 
         public void Switch(Action<T0> f0)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
             throw new InvalidOperationException();
@@ -75,18 +75,18 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
             if (otherwise != null)
             {
@@ -244,14 +244,14 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
             throw new InvalidOperationException();
@@ -259,26 +259,26 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
             if (otherwise != null)
             {
@@ -477,19 +477,19 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
             throw new InvalidOperationException();
@@ -497,34 +497,34 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
             if (otherwise != null)
             {
@@ -764,24 +764,24 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
             throw new InvalidOperationException();
@@ -789,42 +789,42 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
             if (otherwise != null)
             {
@@ -1105,29 +1105,29 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1135,50 +1135,50 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
             if (otherwise != null)
             {
@@ -1500,34 +1500,34 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1535,58 +1535,58 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
             if (otherwise != null)
             {
@@ -1949,39 +1949,39 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1989,66 +1989,66 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
             if (otherwise != null)
             {
@@ -2452,44 +2452,44 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                f7(AsT7);
+                f7(_value7);
                 return; 
             }
             throw new InvalidOperationException();
@@ -2497,74 +2497,74 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
             if (otherwise != null)
             {
@@ -3009,49 +3009,49 @@ namespace OneOf
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                f0(AsT0);
+                f0(_value0);
                 return; 
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                f1(AsT1);
+                f1(_value1);
                 return; 
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                f2(AsT2);
+                f2(_value2);
                 return; 
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                f3(AsT3);
+                f3(_value3);
                 return; 
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                f4(AsT4);
+                f4(_value4);
                 return; 
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                f5(AsT5);
+                f5(_value5);
                 return; 
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                f6(AsT6);
+                f6(_value6);
                 return; 
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                f7(AsT7);
+                f7(_value7);
                 return; 
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                f8(AsT8);
+                f8(_value8);
                 return; 
             }
             throw new InvalidOperationException();
@@ -3059,82 +3059,82 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                return f8(AsT8);
+                return f8(_value8);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-            if (IsT0 && f0 != null)
+            if (_index == 0 && f0 != null)
             {
-                return f0(AsT0);
+                return f0(_value0);
             }
-            if (IsT1 && f1 != null)
+            if (_index == 1 && f1 != null)
             {
-                return f1(AsT1);
+                return f1(_value1);
             }
-            if (IsT2 && f2 != null)
+            if (_index == 2 && f2 != null)
             {
-                return f2(AsT2);
+                return f2(_value2);
             }
-            if (IsT3 && f3 != null)
+            if (_index == 3 && f3 != null)
             {
-                return f3(AsT3);
+                return f3(_value3);
             }
-            if (IsT4 && f4 != null)
+            if (_index == 4 && f4 != null)
             {
-                return f4(AsT4);
+                return f4(_value4);
             }
-            if (IsT5 && f5 != null)
+            if (_index == 5 && f5 != null)
             {
-                return f5(AsT5);
+                return f5(_value5);
             }
-            if (IsT6 && f6 != null)
+            if (_index == 6 && f6 != null)
             {
-                return f6(AsT6);
+                return f6(_value6);
             }
-            if (IsT7 && f7 != null)
+            if (_index == 7 && f7 != null)
             {
-                return f7(AsT7);
+                return f7(_value7);
             }
-            if (IsT8 && f8 != null)
+            if (_index == 8 && f8 != null)
             {
-                return f8(AsT8);
+                return f8(_value8);
             }
             if (otherwise != null)
             {

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -5,32 +5,32 @@ namespace OneOf
 {
     public class OneOfBase<T0> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -43,12 +43,11 @@ namespace OneOf
              return new OneOfBase<T0>(t, 0);
         }
 
-
         public void Switch(Action<T0> f0)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
             throw new InvalidOperationException();
@@ -57,18 +56,18 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
             if (otherwise != null)
             {
@@ -79,17 +78,17 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
         }
 
         bool Equals(OneOfBase<T0> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -112,39 +111,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -160,7 +159,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -173,17 +172,16 @@ namespace OneOf
              return new OneOfBase<T0, T1>(t, 1);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
             throw new InvalidOperationException();
@@ -192,26 +190,26 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
             if (otherwise != null)
             {
@@ -222,22 +220,22 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
         }
 
         bool Equals(OneOfBase<T0, T1> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -260,39 +258,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -308,7 +306,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -324,7 +322,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -337,22 +335,21 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2>(t, 2);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
             throw new InvalidOperationException();
@@ -361,34 +358,34 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
             if (otherwise != null)
             {
@@ -399,27 +396,27 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -442,39 +439,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -490,7 +487,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -506,7 +503,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -522,7 +519,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -535,27 +532,26 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3>(t, 3);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
             throw new InvalidOperationException();
@@ -564,42 +560,42 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
             if (otherwise != null)
             {
@@ -610,32 +606,32 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -658,39 +654,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -706,7 +702,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -722,7 +718,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -738,7 +734,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -754,7 +750,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -767,32 +763,31 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3, T4>(t, 4);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
             throw new InvalidOperationException();
@@ -801,50 +796,50 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
             if (otherwise != null)
             {
@@ -855,37 +850,37 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
 
             if (this is T4)
             {
-                this.index = 4;
+                _index = 4;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -908,39 +903,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -956,7 +951,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -972,7 +967,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -988,7 +983,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1004,7 +999,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1020,7 +1015,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1033,37 +1028,36 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3, T4, T5>(t, 5);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1072,58 +1066,58 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
             if (otherwise != null)
             {
@@ -1134,42 +1128,42 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
 
             if (this is T4)
             {
-                this.index = 4;
+                _index = 4;
             }
 
             if (this is T5)
             {
-                this.index = 5;
+                _index = 5;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1192,39 +1186,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1240,7 +1234,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1256,7 +1250,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1272,7 +1266,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1288,7 +1282,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1304,7 +1298,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1320,7 +1314,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -1333,42 +1327,41 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(t, 6);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1377,66 +1370,66 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
             if (otherwise != null)
             {
@@ -1447,47 +1440,47 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
 
             if (this is T4)
             {
-                this.index = 4;
+                _index = 4;
             }
 
             if (this is T5)
             {
-                this.index = 5;
+                _index = 5;
             }
 
             if (this is T6)
             {
-                this.index = 6;
+                _index = 6;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1510,39 +1503,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1558,7 +1551,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1574,7 +1567,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1590,7 +1583,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1606,7 +1599,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1622,7 +1615,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1638,7 +1631,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -1654,7 +1647,7 @@ namespace OneOf
 
         public bool IsT7
         {
-            get { return index == 7; }
+            get { return _index == 7; }
         }
         
         public T7 AsT7
@@ -1667,47 +1660,46 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(t, 7);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                f7(this.AsT7);
+                f7(AsT7);
                 return; 
             }
             throw new InvalidOperationException();
@@ -1716,74 +1708,74 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
             if (otherwise != null)
             {
@@ -1794,52 +1786,52 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
 
             if (this is T4)
             {
-                this.index = 4;
+                _index = 4;
             }
 
             if (this is T5)
             {
-                this.index = 5;
+                _index = 5;
             }
 
             if (this is T6)
             {
-                this.index = 6;
+                _index = 6;
             }
 
             if (this is T7)
             {
-                this.index = 7;
+                _index = 7;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -1862,39 +1854,39 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
-        readonly object value;
-        readonly int index;
+        readonly object _value;
+        readonly int _index;
         
         OneOfBase(object value, int index)
         {
-            this.value = value; 
-            this.index = index;
+            _value = value; 
+            _index = index;
         }
     
         object IOneOf.Value 
         {
-            get { return value; }
+            get { return _value; }
         }
     
         T Get<T>(int index)
         {
-            if (index != this.index)
+            if (index != _index)
             {
-                throw new InvalidOperationException($"Cannot return as T{index} as result is T{this.index}");
+                throw new InvalidOperationException($"Cannot return as T{index} as result is T{_index}");
             }
-            return (T)value;
+            return (T)_value;
         }
 
         public bool IsT0
         {
-            get { return index == 0; }
+            get { return _index == 0; }
         }
         
         public T0 AsT0
@@ -1910,7 +1902,7 @@ namespace OneOf
 
         public bool IsT1
         {
-            get { return index == 1; }
+            get { return _index == 1; }
         }
         
         public T1 AsT1
@@ -1926,7 +1918,7 @@ namespace OneOf
 
         public bool IsT2
         {
-            get { return index == 2; }
+            get { return _index == 2; }
         }
         
         public T2 AsT2
@@ -1942,7 +1934,7 @@ namespace OneOf
 
         public bool IsT3
         {
-            get { return index == 3; }
+            get { return _index == 3; }
         }
         
         public T3 AsT3
@@ -1958,7 +1950,7 @@ namespace OneOf
 
         public bool IsT4
         {
-            get { return index == 4; }
+            get { return _index == 4; }
         }
         
         public T4 AsT4
@@ -1974,7 +1966,7 @@ namespace OneOf
 
         public bool IsT5
         {
-            get { return index == 5; }
+            get { return _index == 5; }
         }
         
         public T5 AsT5
@@ -1990,7 +1982,7 @@ namespace OneOf
 
         public bool IsT6
         {
-            get { return index == 6; }
+            get { return _index == 6; }
         }
         
         public T6 AsT6
@@ -2006,7 +1998,7 @@ namespace OneOf
 
         public bool IsT7
         {
-            get { return index == 7; }
+            get { return _index == 7; }
         }
         
         public T7 AsT7
@@ -2022,7 +2014,7 @@ namespace OneOf
 
         public bool IsT8
         {
-            get { return index == 8; }
+            get { return _index == 8; }
         }
         
         public T8 AsT8
@@ -2035,52 +2027,51 @@ namespace OneOf
              return new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(t, 8);
         }
 
-
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                f0(this.AsT0);
+                f0(AsT0);
                 return; 
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                f1(this.AsT1);
+                f1(AsT1);
                 return; 
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                f2(this.AsT2);
+                f2(AsT2);
                 return; 
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                f3(this.AsT3);
+                f3(AsT3);
                 return; 
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                f4(this.AsT4);
+                f4(AsT4);
                 return; 
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                f5(this.AsT5);
+                f5(AsT5);
                 return; 
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                f6(this.AsT6);
+                f6(AsT6);
                 return; 
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                f7(this.AsT7);
+                f7(AsT7);
                 return; 
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                f8(this.AsT8);
+                f8(AsT8);
                 return; 
             }
             throw new InvalidOperationException();
@@ -2089,82 +2080,82 @@ namespace OneOf
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                return f8(this.AsT8);
+                return f8(AsT8);
             }
             throw new InvalidOperationException();
         }
 
         public TResult MatchSome<TResult>(Func<T0, TResult> f0 = null, Func<T1, TResult> f1 = null, Func<T2, TResult> f2 = null, Func<T3, TResult> f3 = null, Func<T4, TResult> f4 = null, Func<T5, TResult> f5 = null, Func<T6, TResult> f6 = null, Func<T7, TResult> f7 = null, Func<T8, TResult> f8 = null, Func<TResult> otherwise = null)
         {
-            if (this.IsT0 && f0 != null)
+            if (IsT0 && f0 != null)
             {
-                return f0(this.AsT0);
+                return f0(AsT0);
             }
-            if (this.IsT1 && f1 != null)
+            if (IsT1 && f1 != null)
             {
-                return f1(this.AsT1);
+                return f1(AsT1);
             }
-            if (this.IsT2 && f2 != null)
+            if (IsT2 && f2 != null)
             {
-                return f2(this.AsT2);
+                return f2(AsT2);
             }
-            if (this.IsT3 && f3 != null)
+            if (IsT3 && f3 != null)
             {
-                return f3(this.AsT3);
+                return f3(AsT3);
             }
-            if (this.IsT4 && f4 != null)
+            if (IsT4 && f4 != null)
             {
-                return f4(this.AsT4);
+                return f4(AsT4);
             }
-            if (this.IsT5 && f5 != null)
+            if (IsT5 && f5 != null)
             {
-                return f5(this.AsT5);
+                return f5(AsT5);
             }
-            if (this.IsT6 && f6 != null)
+            if (IsT6 && f6 != null)
             {
-                return f6(this.AsT6);
+                return f6(AsT6);
             }
-            if (this.IsT7 && f7 != null)
+            if (IsT7 && f7 != null)
             {
-                return f7(this.AsT7);
+                return f7(AsT7);
             }
-            if (this.IsT8 && f8 != null)
+            if (IsT8 && f8 != null)
             {
-                return f8(this.AsT8);
+                return f8(AsT8);
             }
             if (otherwise != null)
             {
@@ -2175,57 +2166,57 @@ namespace OneOf
 
         protected OneOfBase()
         {
-            this.value = this;
+            _value = this;
 
             if (this is T0)
             {
-                this.index = 0;
+                _index = 0;
             }
 
             if (this is T1)
             {
-                this.index = 1;
+                _index = 1;
             }
 
             if (this is T2)
             {
-                this.index = 2;
+                _index = 2;
             }
 
             if (this is T3)
             {
-                this.index = 3;
+                _index = 3;
             }
 
             if (this is T4)
             {
-                this.index = 4;
+                _index = 4;
             }
 
             if (this is T5)
             {
-                this.index = 5;
+                _index = 5;
             }
 
             if (this is T6)
             {
-                this.index = 6;
+                _index = 6;
             }
 
             if (this is T7)
             {
-                this.index = 7;
+                _index = 7;
             }
 
             if (this is T8)
             {
-                this.index = 8;
+                _index = 8;
             }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)
         {
-            return index == other.index && Equals(value, other.value);
+            return _index == other._index && Equals(_value, other._value);
         }
 
         public override bool Equals(object obj)
@@ -2248,7 +2239,7 @@ namespace OneOf
         {
             unchecked
             {
-                return ((value?.GetHashCode() ?? 0)*397) ^ index;
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
             }
         }
     }

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -1,4 +1,3 @@
-
 using System;
 
 namespace OneOf
@@ -13,7 +12,17 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -53,7 +62,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {
             if (IsT0 && f0 != null)
@@ -74,16 +82,6 @@ namespace OneOf
                 return otherwise();
             }
             throw new InvalidOperationException();
-        }
-
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
         }
 
         bool Equals(OneOfBase<T0> other)
@@ -126,7 +124,22 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -187,7 +200,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {
             if (IsT0 && f0 != null)
@@ -216,21 +228,6 @@ namespace OneOf
                 return otherwise();
             }
             throw new InvalidOperationException();
-        }
-
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
         }
 
         bool Equals(OneOfBase<T0, T1> other)
@@ -273,7 +270,27 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -355,7 +372,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {
             if (IsT0 && f0 != null)
@@ -392,26 +408,6 @@ namespace OneOf
                 return otherwise();
             }
             throw new InvalidOperationException();
-        }
-
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
         }
 
         bool Equals(OneOfBase<T0, T1, T2> other)
@@ -454,7 +450,32 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+
+            if (this is T3)
+            {
+                _index = 3;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -557,7 +578,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {
             if (IsT0 && f0 != null)
@@ -604,31 +624,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
-
-            if (this is T3)
-            {
-                _index = 3;
-            }
-        }
-
         bool Equals(OneOfBase<T0, T1, T2, T3> other)
         {
             return _index == other._index && Equals(_value, other._value);
@@ -669,7 +664,37 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+
+            if (this is T3)
+            {
+                _index = 3;
+            }
+
+            if (this is T4)
+            {
+                _index = 4;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -793,7 +818,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {
             if (IsT0 && f0 != null)
@@ -848,36 +872,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
-
-            if (this is T3)
-            {
-                _index = 3;
-            }
-
-            if (this is T4)
-            {
-                _index = 4;
-            }
-        }
-
         bool Equals(OneOfBase<T0, T1, T2, T3, T4> other)
         {
             return _index == other._index && Equals(_value, other._value);
@@ -918,7 +912,42 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+
+            if (this is T3)
+            {
+                _index = 3;
+            }
+
+            if (this is T4)
+            {
+                _index = 4;
+            }
+
+            if (this is T5)
+            {
+                _index = 5;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1063,7 +1092,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {
             if (IsT0 && f0 != null)
@@ -1126,41 +1154,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
-
-            if (this is T3)
-            {
-                _index = 3;
-            }
-
-            if (this is T4)
-            {
-                _index = 4;
-            }
-
-            if (this is T5)
-            {
-                _index = 5;
-            }
-        }
-
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other)
         {
             return _index == other._index && Equals(_value, other._value);
@@ -1201,7 +1194,47 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+
+            if (this is T3)
+            {
+                _index = 3;
+            }
+
+            if (this is T4)
+            {
+                _index = 4;
+            }
+
+            if (this is T5)
+            {
+                _index = 5;
+            }
+
+            if (this is T6)
+            {
+                _index = 6;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1367,7 +1400,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {
             if (IsT0 && f0 != null)
@@ -1438,46 +1470,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
-
-            if (this is T3)
-            {
-                _index = 3;
-            }
-
-            if (this is T4)
-            {
-                _index = 4;
-            }
-
-            if (this is T5)
-            {
-                _index = 5;
-            }
-
-            if (this is T6)
-            {
-                _index = 6;
-            }
-        }
-
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other)
         {
             return _index == other._index && Equals(_value, other._value);
@@ -1518,7 +1510,52 @@ namespace OneOf
             _value = value; 
             _index = index;
         }
-    
+
+        protected OneOfBase()
+        {
+            _value = this;
+
+            if (this is T0)
+            {
+                _index = 0;
+            }
+
+            if (this is T1)
+            {
+                _index = 1;
+            }
+
+            if (this is T2)
+            {
+                _index = 2;
+            }
+
+            if (this is T3)
+            {
+                _index = 3;
+            }
+
+            if (this is T4)
+            {
+                _index = 4;
+            }
+
+            if (this is T5)
+            {
+                _index = 5;
+            }
+
+            if (this is T6)
+            {
+                _index = 6;
+            }
+
+            if (this is T7)
+            {
+                _index = 7;
+            }
+        }
+
         object IOneOf.Value 
         {
             get { return _value; }
@@ -1705,7 +1742,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {
             if (IsT0 && f0 != null)
@@ -1784,6 +1820,47 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
+        {
+            return _index == other._index && Equals(_value, other._value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>;
+            return other != null && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+            }
+        }
+    }
+
+    public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+    {
+        readonly object _value;
+        readonly int _index;
+        
+        OneOfBase(object value, int index)
+        {
+            _value = value; 
+            _index = index;
+        }
+
         protected OneOfBase()
         {
             _value = this;
@@ -1827,49 +1904,13 @@ namespace OneOf
             {
                 _index = 7;
             }
-        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other)
-        {
-            return _index == other._index && Equals(_value, other._value);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
+            if (this is T8)
             {
-                return false;
-            }
-
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
-            var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>;
-            return other != null && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((_value?.GetHashCode() ?? 0)*397) ^ _index;
+                _index = 8;
             }
         }
-    }
 
-    public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
-    {
-        readonly object _value;
-        readonly int _index;
-        
-        OneOfBase(object value, int index)
-        {
-            _value = value; 
-            _index = index;
-        }
-    
         object IOneOf.Value 
         {
             get { return _value; }
@@ -2077,7 +2118,6 @@ namespace OneOf
             throw new InvalidOperationException();
         }
 
-
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {
             if (IsT0 && f0 != null)
@@ -2162,56 +2202,6 @@ namespace OneOf
                 return otherwise();
             }
             throw new InvalidOperationException();
-        }
-
-        protected OneOfBase()
-        {
-            _value = this;
-
-            if (this is T0)
-            {
-                _index = 0;
-            }
-
-            if (this is T1)
-            {
-                _index = 1;
-            }
-
-            if (this is T2)
-            {
-                _index = 2;
-            }
-
-            if (this is T3)
-            {
-                _index = 3;
-            }
-
-            if (this is T4)
-            {
-                _index = 4;
-            }
-
-            if (this is T5)
-            {
-                _index = 5;
-            }
-
-            if (this is T6)
-            {
-                _index = 6;
-            }
-
-            if (this is T7)
-            {
-                _index = 7;
-            }
-
-            if (this is T8)
-            {
-                _index = 8;
-            }
         }
 
         bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other)


### PR DESCRIPTION
I've done this part in another pull request, because there I made a decision that I'm not sure you'll agree with. The 2 pull requests contain the same changes, but this one has a bit more.

In order to get the protected constructor working in ```OneOfBase```, the type parameters have been restricted to classes. I believe this is the intended use, but if it shouldn't be restricted like this, I can find another way to implement it.

fixes #11 