### PR TITLE
Added failing test for serialization of object that inherits from One…

### DIFF
--- a/OneOf.Tests/OneOfBaseSerialization.cs
+++ b/OneOf.Tests/OneOfBaseSerialization.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace OneOf.Tests
+{
+	public class OneOfBaseSerialization
+	{
+		[Test]
+		public void CanSerializeOneOfBaseValueTransparently()
+		{
+			//Given an object with a OneOf property 
+			var x = new SomeBaseThing.SomeConcreteThing{Value = "Some value"};
+
+			//When that object is serialized
+			var jsonSerializerSettings = new JsonSerializerSettings
+			{
+				Converters = {new OneOfJsonConverter()}
+			};
+			var json = JsonConvert.SerializeObject(x, jsonSerializerSettings);
+			var x2 = JsonConvert.DeserializeObject<SomeBaseThing.SomeConcreteThing>(json, jsonSerializerSettings);
+			Assert.AreEqual(x.Value, x2.Value);
+		}
+	}
+
+	public abstract class SomeBaseThing : OneOfBase<SomeBaseThing.SomeConcreteThing>
+	{
+		public class SomeConcreteThing : SomeBaseThing
+		{
+			public string Value { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I have a question, and a pull request seemed like a good way to illustrate the question. 
If I have a type that inherits from the OneOfBase class the JsonSerializer example doesn't work. The error I get is:  
`
Newtonsoft.Json.JsonSerializationException : Self referencing loop detected with type 'OneOf.Tests.SomeBaseThing+SomeConcreteThing'. Path ''.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.CheckForCircularReference(JsonWriter writer, Object value, JsonProperty property, JsonContract contract, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeConvertable(JsonWriter writer, JsonConverter converter, Object value, JsonContract contract, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at .......................
`
I've tried some stuff with `ReferenceLoopHandling = ReferenceLoopHandling.Serialize` and `PreserveReferencesHandling = PreserveReferencesHandling.Objects` but I can't get it to work. Do you have an idea if/how there is a way to get this working?

I'm really enjoying the library. Thanks for it!

kind regards,

Arno den Uijl
