### PR TITLE
Add support for .NET45

### DIFF
--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
     <Company>Harry McIntyre</Company>


### PR DESCRIPTION
There's nothing in the library today that requires 4.5.1, so by removing that 1 character it increases the compatibility of the library.