### PR TITLE
Add CLS-compliant attribute

### DIFF
--- a/OneOf.Extended/Assembly.cs
+++ b/OneOf.Extended/Assembly.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]

--- a/OneOf/Assembly.cs
+++ b/OneOf/Assembly.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]


### PR DESCRIPTION
Downstream consumers of these packages will get warnings about them not
being CLS-compliant. By adding the `CLSCompliantAttribute` at the
assembly level this warning is eliminated.

This should not be a breaking change for consumers of these packages.