### PR TITLE
Add ToString overload to sensibly format values

### DIFF
--- a/OneOf.Extended/OneOf.cs
+++ b/OneOf.Extended/OneOf.cs
@@ -704,6 +704,24 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>)obj);
         }
 
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+        }
+
         public override int GetHashCode()
         {
             unchecked
@@ -1526,6 +1544,25 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2431,6 +2468,26 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -3419,6 +3476,27 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -4492,6 +4570,28 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -5652,6 +5752,29 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -6901,6 +7024,30 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -8241,6 +8388,31 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -9674,6 +9846,32 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -11202,6 +11400,33 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -12827,6 +13052,34 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -14551,6 +14804,35 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -16376,6 +16658,36 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -18304,6 +18616,37 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -20337,6 +20680,38 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -22477,6 +22852,39 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -24726,6 +25134,40 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -27086,6 +27528,41 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -29559,6 +30036,42 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -32147,6 +32660,43 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -34852,6 +35402,44 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -37676,6 +38264,45 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                case 30: return FormatValue(typeof(T30), _value30);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -40621,6 +41248,46 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                case 30: return FormatValue(typeof(T30), _value30);
+                case 31: return FormatValue(typeof(T31), _value31);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()

--- a/OneOf.Extended/OneOfBase.cs
+++ b/OneOf.Extended/OneOfBase.cs
@@ -522,6 +522,24 @@ namespace OneOf
             return other != null && Equals(other);
         }
 
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+        }
+
         public override int GetHashCode()
         {
             unchecked
@@ -1132,6 +1150,25 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1793,6 +1830,26 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2503,6 +2560,27 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -3262,6 +3340,28 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -4070,6 +4170,29 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -4927,6 +5050,30 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -5833,6 +5980,31 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -6788,6 +6960,32 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -7792,6 +7990,33 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -8845,6 +9070,34 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -9947,6 +10200,35 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -11098,6 +11380,36 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -12298,6 +12610,37 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -13547,6 +13890,38 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -14845,6 +15220,39 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -16192,6 +16600,40 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -17588,6 +18030,41 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -19033,6 +19510,42 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -20527,6 +21040,43 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -22070,6 +22620,44 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -23662,6 +24250,45 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                case 30: return FormatValue(typeof(T30), _value30);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -25303,6 +25930,46 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                case 9: return FormatValue(typeof(T9), _value9);
+                case 10: return FormatValue(typeof(T10), _value10);
+                case 11: return FormatValue(typeof(T11), _value11);
+                case 12: return FormatValue(typeof(T12), _value12);
+                case 13: return FormatValue(typeof(T13), _value13);
+                case 14: return FormatValue(typeof(T14), _value14);
+                case 15: return FormatValue(typeof(T15), _value15);
+                case 16: return FormatValue(typeof(T16), _value16);
+                case 17: return FormatValue(typeof(T17), _value17);
+                case 18: return FormatValue(typeof(T18), _value18);
+                case 19: return FormatValue(typeof(T19), _value19);
+                case 20: return FormatValue(typeof(T20), _value20);
+                case 21: return FormatValue(typeof(T21), _value21);
+                case 22: return FormatValue(typeof(T22), _value22);
+                case 23: return FormatValue(typeof(T23), _value23);
+                case 24: return FormatValue(typeof(T24), _value24);
+                case 25: return FormatValue(typeof(T25), _value25);
+                case 26: return FormatValue(typeof(T26), _value26);
+                case 27: return FormatValue(typeof(T27), _value27);
+                case 28: return FormatValue(typeof(T28), _value28);
+                case 29: return FormatValue(typeof(T29), _value29);
+                case 30: return FormatValue(typeof(T30), _value30);
+                case 31: return FormatValue(typeof(T31), _value31);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()

--- a/OneOf.Tests/ToStringTests.cs
+++ b/OneOf.Tests/ToStringTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+namespace OneOf.Tests
+{
+    public class ToStringTests
+    {
+        static string RunInCulture(CultureInfo culture, Func<string> action)
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = culture;
+            try
+            {
+                return action();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
+        public string LeftSideFormatsWithCurrentCulture(string cultureName)
+        {
+            return RunInCulture(new CultureInfo(cultureName, false), () =>
+            {
+                OneOf<DateTime, string> a = new DateTime(2019, 1, 2, 1, 2, 3);
+                return a.ToString();
+            });
+        }
+
+        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
+        public string RightSideFormatsWithCurrentCulture(string cultureName)
+        {
+            return RunInCulture(new CultureInfo(cultureName, false), () =>
+            {
+                OneOf<string, DateTime> a = new DateTime(2019, 1, 2, 1, 2, 3);
+                return a.ToString();
+            });
+        }
+
+        [Test]
+        public void TheValueAndTypeNameAreFormattedCorrectly()
+        {
+            OneOf<string, int, DateTime, decimal> a = 42;
+            Assert.AreEqual("System.Int32: 42", a.ToString());
+        }
+    }
+}

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -267,7 +267,19 @@ namespace OneOf
             return other != null && Equals(other);");
 		}
 
-		sb.AppendLine(@"        }
+        sb.AppendLine(@"        }");
+        sb.AppendLine(@"
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $""{type.FullName}: {value.ToString()}"";
+            switch(_index) {");
+        for(var j = 0; j < i; j++) {
+            sb.AppendLine($"                case {j}: return FormatValue(typeof(T{j}), _value{j});");
+        }
+        sb.Append(@"                default: throw new InvalidOperationException(""Unexpected index, which indicates a problem in the OneOf codegen."");
+            }
+        }");
+        sb.AppendLine(@"
 
         public override int GetHashCode()
         {

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -101,6 +101,15 @@ namespace OneOf
             return obj is OneOf<T0> && Equals((OneOf<T0>)obj);
         }
 
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+        }
+
         public override int GetHashCode()
         {
             unchecked
@@ -280,6 +289,16 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1> && Equals((OneOf<T0, T1>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -528,6 +547,17 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2> && Equals((OneOf<T0, T1, T2>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -841,6 +871,18 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3> && Equals((OneOf<T0, T1, T2, T3>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1221,6 +1263,19 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4> && Equals((OneOf<T0, T1, T2, T3, T4>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1670,6 +1725,20 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5> && Equals((OneOf<T0, T1, T2, T3, T4, T5>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2190,6 +2259,21 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2783,6 +2867,22 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -3451,6 +3551,23 @@ namespace OneOf
             
 
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> && Equals((OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>)obj);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -99,6 +99,15 @@ namespace OneOf
             return other != null && Equals(other);
         }
 
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+        }
+
         public override int GetHashCode()
         {
             unchecked
@@ -264,6 +273,16 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -484,6 +503,17 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -753,6 +783,18 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1071,6 +1113,19 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1438,6 +1493,20 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -1854,6 +1923,21 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2319,6 +2403,22 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()
@@ -2833,6 +2933,23 @@ namespace OneOf
 
             var other = obj as OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>;
             return other != null && Equals(other);
+        }
+
+        public override string ToString()
+        {
+            string FormatValue<T>(Type type, T value) => $"{type.FullName}: {value.ToString()}";
+            switch(_index) {
+                case 0: return FormatValue(typeof(T0), _value0);
+                case 1: return FormatValue(typeof(T1), _value1);
+                case 2: return FormatValue(typeof(T2), _value2);
+                case 3: return FormatValue(typeof(T3), _value3);
+                case 4: return FormatValue(typeof(T4), _value4);
+                case 5: return FormatValue(typeof(T5), _value5);
+                case 6: return FormatValue(typeof(T6), _value6);
+                case 7: return FormatValue(typeof(T7), _value7);
+                case 8: return FormatValue(typeof(T8), _value8);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
As discussed in issue #40, we want to format the type using the current
culture in this format:

{FullTypeNameOfInnerValue} {innerValue.ToString()}