### PR TITLE
Implicit conversion from smaller OneOf and support for rearranging members (using permutations) up to T5

### DIFF
--- a/OneOf.Tests/RearrangeTests.cs
+++ b/OneOf.Tests/RearrangeTests.cs
@@ -9,39 +9,39 @@ namespace OneOf.Tests
         [Test]
         public void CanRearrangeEquivalentOneOfValueTypesets()
         {
-			OneOf<byte,short,int,long> value = 123;
-			OneOf<long,int,short,byte> rearranged = OneOf<long,int,short,byte>.RearrangeFrom( value );
+            OneOf<byte,short,int,long> value = 123;
+            OneOf<long,int,short,byte> rearranged = OneOf<long,int,short,byte>.RearrangeFrom( value );
 
             bool isInt123 = false;
-			rearranged.Switch(
-				i64 => Assert.Fail(),
-				i32 => isInt123 = true,
-				i16 => Assert.Fail(),
-				u8  => Assert.Fail()
-			);
+            rearranged.Switch(
+                i64 => Assert.Fail(),
+                i32 => isInt123 = true,
+                i16 => Assert.Fail(),
+                u8  => Assert.Fail()
+            );
 
-			Assert.IsTrue( isInt123 );
+            Assert.IsTrue( isInt123 );
         }
 
-		/* Uncomment this to reveal a compilation/intellisense error that `value` cannot be used as an argument for `RearrangeFrom`.
+        /* Uncomment this to reveal a compilation/intellisense error that `value` cannot be used as an argument for `RearrangeFrom`.
 
-		[Test]
+        [Test]
         public void CannotRearrangeOneOfValuesWithDifferentValueTypeSets()
         {
-			OneOf<byte,short,int,long> value = 123;
-			OneOf<long,int,string,byte> rearranged = OneOf<long,int,string,byte>.RearrangeFrom( value );
+            OneOf<byte,short,int,long> value = 123;
+            OneOf<long,int,string,byte> rearranged = OneOf<long,int,string,byte>.RearrangeFrom( value );
 
             bool isInt123 = false;
-			rearranged.Switch(
-				i64 => Assert.Fail(),
-				i32 => isInt123 = true,
-				i16 => Assert.Fail(),
-				u8  => Assert.Fail()
-			);
+            rearranged.Switch(
+                i64 => Assert.Fail(),
+                i32 => isInt123 = true,
+                i16 => Assert.Fail(),
+                u8  => Assert.Fail()
+            );
 
-			Assert.IsTrue( isInt123 );
+            Assert.IsTrue( isInt123 );
         }
 
-		*/
+        */
     }
 }

--- a/OneOf.Tests/RearrangeTests.cs
+++ b/OneOf.Tests/RearrangeTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Globalization;
+using NUnit.Framework;
+using OneOf;
+
+namespace OneOf.Tests
+{
+    public class RearrangeTests
+    {
+        [Test]
+        public void CanRearrangeEquivalentOneOfValueTypesets()
+        {
+			OneOf<byte,short,int,long> value = 123;
+			OneOf<long,int,short,byte> rearranged = OneOf<long,int,short,byte>.RearrangeFrom( value );
+
+            bool isInt123 = false;
+			rearranged.Switch(
+				i64 => Assert.Fail(),
+				i32 => isInt123 = true,
+				i16 => Assert.Fail(),
+				u8  => Assert.Fail()
+			);
+
+			Assert.IsTrue( isInt123 );
+        }
+
+		/* Uncomment this to reveal a compilation/intellisense error that `value` cannot be used as an argument for `RearrangeFrom`.
+
+		[Test]
+        public void CannotRearrangeOneOfValuesWithDifferentValueTypeSets()
+        {
+			OneOf<byte,short,int,long> value = 123;
+			OneOf<long,int,string,byte> rearranged = OneOf<long,int,string,byte>.RearrangeFrom( value );
+
+            bool isInt123 = false;
+			rearranged.Switch(
+				i64 => Assert.Fail(),
+				i32 => isInt123 = true,
+				i16 => Assert.Fail(),
+				u8  => Assert.Fail()
+			);
+
+			Assert.IsTrue( isInt123 );
+        }
+
+		*/
+    }
+}

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -332,7 +332,6 @@ public void RenderOneOf(StringBuilder sb, string className, string genericArg, b
 	{
 		sb.AppendLine();
 		sb.AppendLine("#region Rearrange (not subset)");
-		sb.AppendLine();
 
 		String[] typeParameters = Enumerable.Range(0, i).Select(e => $"T{e}").ToArray();
 		var permutations = GetPermutations(typeParameters);
@@ -342,15 +341,58 @@ public void RenderOneOf(StringBuilder sb, string className, string genericArg, b
 
 			String matchFuncs = String.Join(", ", Enumerable.Range(0, i).Select(n => $"v{n} => v{n}"));
 
-			sb.AppendLine($@"        public static {className}<{genericArg}> RearrangeFrom( {className}<{permutation}> other ) => other.Match< {className}<{genericArg}> >( {matchFuncs} );");
 			sb.AppendLine();
+			sb.AppendLine($@"        public static {className}<{genericArg}> RearrangeFrom( {className}<{permutation}> other ) => other.Match< {className}<{genericArg}> >( {matchFuncs} );");
 		}
 
 		sb.AppendLine();
 		sb.AppendLine("#endregion");
-
 		sb.AppendLine();
 	}
 
+	if( i <= 8 )
+	{
+		sb.AppendLine("#region Extend (Explicit addition of (empty) type arguments)");
+
+		String matchFuncs = String.Join(", ", Enumerable.Range(0, i).Select(n => $"v{n} => v{n}"));
+
+		Int32 ei = 1;
+		for( int s = i; s < 9; s++ )
+		{
+			String genericArgExtend = String.Join(", ", Enumerable.Range( i, ei ).Select(n => $"T{n}"));
+
+
+			sb.AppendLine();
+			sb.AppendLine($@"        public {className}<{genericArg}, {genericArgExtend}> Extend<{genericArgExtend}>() => this.Match< {className}<{genericArg}, {genericArgExtend}> >( {matchFuncs} );");
+
+			ei++;
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("#endregion");
+		sb.AppendLine();
+	}
+
+	if( i <= 8 )
+	{
+		sb.AppendLine("#region Implicit conversion from subset (without rearranging type arguments)");
+
+		Int32 ei = 1;
+		for( int s = i - 1; s > 0; s-- )
+		{
+			String genericArgMinus  = String.Join( ", ", Enumerable.Range( 0, s  ).Select(n => $"T{n}") );
+			String genericArgExtend = String.Join( ", ", Enumerable.Range( s, ei ).Select(n => $"T{n}") );
+
+			sb.AppendLine();
+			sb.AppendLine($@"        public static implicit operator {className}<{genericArg}>( {className}<{genericArgMinus}> smaller ) => smaller.Extend<{genericArgExtend}>();" );
+
+			ei++;
+		}
+
+		sb.AppendLine();
+		sb.AppendLine("#endregion");
+		sb.AppendLine();
+	}
+	
 	sb.AppendLine(@"    }");
 }

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -338,7 +338,7 @@ public void RenderOneOf(StringBuilder sb, string className, string genericArg, b
 		var permutations = GetPermutations(typeParameters);
 		foreach (String[] typeParameterPermutation in permutations)
 		{
-			String permutation = String.Join(",", typeParameterPermutation);
+			String permutation = String.Join(", ", typeParameterPermutation);
 
 			String matchFuncs = String.Join(", ", Enumerable.Range(0, i).Select(n => $"v{n} => v{n}"));
 
@@ -351,6 +351,6 @@ public void RenderOneOf(StringBuilder sb, string className, string genericArg, b
 
 		sb.AppendLine();
 	}
-	
+
 	sb.AppendLine(@"    }");
 }

--- a/OneOf/CreateFile.linq
+++ b/OneOf/CreateFile.linq
@@ -35,71 +35,80 @@ namespace OneOf
 		sb.AppendLine($@"
     public {(isStruct ? "struct" : "class")} {className}<{genericArg}> : IOneOf");
 		sb.AppendLine("    {");
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine($@"        readonly T{j} _value{j};");
-		}
+		
+		RenderOneOf(sb, className, genericArg, isStruct, i);
+	}
+	sb.AppendLine("}");
+	return sb.ToString(); ;
+}
 
-		sb.Append($@"        readonly int _index;
+public void RenderOneOf(StringBuilder sb, string className, string genericArg, bool isStruct, int i)
+{
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($@"        readonly T{j} _value{j};");
+	}
+
+	sb.Append($@"        readonly int _index;
 
         {(isStruct ? "" : "protected ")}{className}(int index");
-		for (var j = 0; j < i; j++)
-		{
-			sb.Append($", T{j} value{j} = default(T{j})");
-		}
-		sb.Append(@")
+	for (var j = 0; j < i; j++)
+	{
+		sb.Append($", T{j} value{j} = default(T{j})");
+	}
+	sb.Append(@")
         {
             _index = index;");
-		for (var j = 0; j < i; j++)
-		{
-			sb.Append($@"
+	for (var j = 0; j < i; j++)
+	{
+		sb.Append($@"
             _value{j} = value{j};");
-		}
-		sb.AppendLine(@"
+	}
+	sb.AppendLine(@"
         }");
 
-		if (!isStruct)
-		{
-			sb.AppendLine($@"
+	if (!isStruct)
+	{
+		sb.AppendLine($@"
         protected {className}()
         {{");
 
-			for (var j = 0; j < i; j++)
-			{
-				sb.AppendLine($@"            if (this is T{j})
+		for (var j = 0; j < i; j++)
+		{
+			sb.AppendLine($@"            if (this is T{j})
             {{
                 _index = {j};
                 _value{j} = (T{j})(object)this;
                 return;
             }}");
-			}
-
-			sb.AppendLine(@"        }");
 		}
 
-		sb.Append(@"
+		sb.AppendLine(@"        }");
+	}
+
+	sb.Append(@"
         public object Value
         {
             get
             {
                 switch (_index)
                 {");
-		for (var j = 0; j < i; j++)
-		{
-			sb.Append($@"
+	for (var j = 0; j < i; j++)
+	{
+		sb.Append($@"
                     case {j}:
                         return _value{j};");
-		}
-		sb.AppendLine(@"
+	}
+	sb.AppendLine(@"
                     default:
                         throw new InvalidOperationException();
                 }
             }
         }");
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine(
-		$@"
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine(
+	$@"
         public bool IsT{j} => _index == {j};
 
         public T{j} AsT{j}
@@ -116,121 +125,121 @@ namespace OneOf
 
         public static implicit operator {className}<{genericArg}>(T{j} t) => new {className}<{genericArg}>({j}, value{j}: t);
 ");
-		}
+	}
 
-		var matchArgList0 = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Action<T{e}> f{e}"));
-		sb.AppendLine($@"
+	var matchArgList0 = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Action<T{e}> f{e}"));
+	sb.AppendLine($@"
         public void Switch({matchArgList0})
         {{");
 
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine($@"            if (_index == {j} && f{j} != null)
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($@"            if (_index == {j} && f{j} != null)
             {{
                 f{j}(_value{j});
                 return;
             }}");
-		}
+	}
 
-		sb.AppendLine(@"            throw new InvalidOperationException();
+	sb.AppendLine(@"            throw new InvalidOperationException();
         }");
 
-		var matchArgList = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Func<T{e}, TResult> f{e}"));
-		sb.AppendLine($@"
+	var matchArgList = string.Join(", ", Enumerable.Range(0, i).Select(e => $"Func<T{e}, TResult> f{e}"));
+	sb.AppendLine($@"
         public TResult Match<TResult>({matchArgList})
         {{");
 
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine($@"            if (_index == {j} && f{j} != null)
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($@"            if (_index == {j} && f{j} != null)
             {{
                 return f{j}(_value{j});
             }}");
-		}
+	}
 
-		sb.AppendLine(@"            throw new InvalidOperationException();
+	sb.AppendLine(@"            throw new InvalidOperationException();
         }");
 
-		if (isStruct)
-		{
-			var argIndexList = Enumerable.Range(0, i).ToList();
-			var genericArgs = argIndexList.Select(e => $"T{e}").ToList();
-			var genericArgsPrinted = string.Join(", ", genericArgs);
+	if (isStruct)
+	{
+		var argIndexList = Enumerable.Range(0, i).ToList();
+		var genericArgs = argIndexList.Select(e => $"T{e}").ToList();
+		var genericArgsPrinted = string.Join(", ", genericArgs);
 
-			foreach (var bindToType in genericArgs)
-			{
-				sb.AppendLine($@"
+		foreach (var bindToType in genericArgs)
+		{
+			sb.AppendLine($@"
         public static OneOf<{genericArgsPrinted}> From{bindToType}({bindToType} input)
         {{
             return input;
         }}");
-			}
+		}
 
-			foreach (var bindToType in genericArgs)
+		foreach (var bindToType in genericArgs)
+		{
+
+			var resultType = "TResult";
+			var resultArgs = genericArgs.Select(x =>
 			{
-
-				var resultType = "TResult";
-				var resultArgs = genericArgs.Select(x =>
-				{
-					return x == bindToType ? resultType : x;
-				}).ToList();
-				var resultArgsPrinted = string.Join(", ", resultArgs);
-				var funcType =
-				sb.Append($@"
+				return x == bindToType ? resultType : x;
+			}).ToList();
+			var resultArgsPrinted = string.Join(", ", resultArgs);
+			var funcType =
+			sb.Append($@"
         public OneOf<{resultArgsPrinted}> Map{bindToType}<{resultType}>(Func<{bindToType}, {resultType}> mapFunc)
         {{");
-				sb.Append($@"
+			sb.Append($@"
             if(mapFunc == null)
             {{
                 throw new ArgumentNullException(nameof(mapFunc));
             }}");
 
-				sb.Append($@"
+			sb.Append($@"
             return Match<OneOf<{resultArgsPrinted}>>(");
-				var appendStrings = argIndexList.Select(x =>
-				{
-					return $"T{x}" == bindToType ?
-						$"input{x} => mapFunc(input{x})" :
-						$"input{x} => input{x}";
-				}).ToList();
-				for (var appendedStringIndex = 0; appendedStringIndex < appendStrings.Count; appendedStringIndex++)
-				{
-					if (appendedStringIndex != appendStrings.Count - 1)
-					{
-						sb.Append($@"
-                {appendStrings[appendedStringIndex]},");
-					}
-					else
-					{
-						sb.Append($@"
-                {appendStrings[appendedStringIndex]}");
-					}
-				}
-				sb.Append($@"
-            );");
-				sb.AppendLine($@"
-        }}");
-			}
-
-		}
-		if (i > 1)
-			for (var j = 0; j < i; j++)
+			var appendStrings = argIndexList.Select(x =>
 			{
+				return $"T{x}" == bindToType ?
+					$"input{x} => mapFunc(input{x})" :
+					$"input{x} => input{x}";
+			}).ToList();
+			for (var appendedStringIndex = 0; appendedStringIndex < appendStrings.Count; appendedStringIndex++)
+			{
+				if (appendedStringIndex != appendStrings.Count - 1)
+				{
+					sb.Append($@"
+                {appendStrings[appendedStringIndex]},");
+				}
+				else
+				{
+					sb.Append($@"
+                {appendStrings[appendedStringIndex]}");
+				}
+			}
+			sb.Append($@"
+            );");
+			sb.AppendLine($@"
+        }}");
+		}
 
-				var genericArgWithSkip = string.Join(", ", Enumerable.Range(0, i).Except(new[] { j }).Select(e => $"T{e}"));
-				var remainderType = i == 2 ? genericArgWithSkip : $"OneOf<{genericArgWithSkip}>";
-				sb.AppendLine($@"
+	}
+	if (i > 1)
+		for (var j = 0; j < i; j++)
+		{
+
+			var genericArgWithSkip = string.Join(", ", Enumerable.Range(0, i).Except(new[] { j }).Select(e => $"T{e}"));
+			var remainderType = i == 2 ? genericArgWithSkip : $"OneOf<{genericArgWithSkip}>";
+			sb.AppendLine($@"
 		public bool TryPickT{j}(out T{j} value, out {remainderType} remainder)
 		{{
 			value = this.IsT{j} ? this.AsT{j} : default(T{j});
 			remainder = " + ((i == 2) ? ($"this.IsT{j} ? default({remainderType}) : this.As{remainderType};") : $@"this.IsT{j}
 				? default(OneOf<{genericArgWithSkip}>) 
 				: this.Match<{remainderType}>(" + String.Join(", ", Enumerable.Range(0, i).Select(k => $"t{k} =>" + (k == j ? "throw new InvalidOperationException()" : $"t{k}"))) + $@");")
-				+ $@"
+			+ $@"
 			return this.IsT{j};
 		}}");
-			}
-		sb.AppendLine($@"
+		}
+	sb.AppendLine($@"
         bool Equals({className}<{genericArg}> other)
         {{
             if (_index != other._index)
@@ -239,11 +248,11 @@ namespace OneOf
             }}
             switch (_index)
             {{");
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine($@"                case {j}: return Equals(_value{j}, other._value{j});");
-		}
-		sb.AppendLine(@"                default: return false;
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($@"                case {j}: return Equals(_value{j}, other._value{j});");
+	}
+	sb.AppendLine(@"                default: return false;
             }
         }
 
@@ -252,40 +261,42 @@ namespace OneOf
             if (ReferenceEquals(null, obj))
                 return false;
             ");
-		if (isStruct)
-		{
-			sb.AppendLine($@"
+	if (isStruct)
+	{
+		sb.AppendLine($@"
             return obj is {className}<{genericArg}> && Equals(({className}<{genericArg}>)obj);");
-		}
-		else
-		{
-			sb.AppendLine($@"
+	}
+	else
+	{
+		sb.AppendLine($@"
             if (ReferenceEquals(this, obj))
                 return true;
 
             var other = obj as OneOfBase<{genericArg}>;
             return other != null && Equals(other);");
-		}
+	}
 
-        sb.AppendLine(@"        }");
-        sb.AppendLine(@"
+	sb.AppendLine(@"        }");
+	sb.AppendLine(@"
         public override string ToString()
         {");
-        if(isStruct){
-            sb.AppendLine(@"            string FormatValue<T>(Type type, T value) => $""{type.FullName}: {value?.ToString()}"";");
-        }
-        else
-        {
-            sb.AppendLine(@"            string FormatValue<T>(Type type, T value) => object.ReferenceEquals(this, value) ? base.ToString() : $""{type.FullName}: {value?.ToString()}"";");
-        }
-        sb.AppendLine(@"            switch(_index) {");
-        for(var j = 0; j < i; j++) {
-            sb.AppendLine($"                case {j}: return FormatValue(typeof(T{j}), _value{j});");
-        }
-        sb.Append(@"                default: throw new InvalidOperationException(""Unexpected index, which indicates a problem in the OneOf codegen."");
+	if (isStruct)
+	{
+		sb.AppendLine(@"            string FormatValue<T>(Type type, T value) => $""{type.FullName}: {value?.ToString()}"";");
+	}
+	else
+	{
+		sb.AppendLine(@"            string FormatValue<T>(Type type, T value) => object.ReferenceEquals(this, value) ? base.ToString() : $""{type.FullName}: {value?.ToString()}"";");
+	}
+	sb.AppendLine(@"            switch(_index) {");
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($"                case {j}: return FormatValue(typeof(T{j}), _value{j});");
+	}
+	sb.Append(@"                default: throw new InvalidOperationException(""Unexpected index, which indicates a problem in the OneOf codegen."");
             }
         }");
-        sb.AppendLine(@"
+	sb.AppendLine(@"
 
         public override int GetHashCode()
         {
@@ -294,13 +305,13 @@ namespace OneOf
                 int hashCode;
                 switch (_index)
                 {");
-		for (var j = 0; j < i; j++)
-		{
-			sb.AppendLine($@"                    case {j}:
+	for (var j = 0; j < i; j++)
+	{
+		sb.AppendLine($@"                    case {j}:
                     hashCode = _value{j}?.GetHashCode() ?? 0;
                     break;");
-		}
-		sb.AppendLine(@"                    default:
+	}
+	sb.AppendLine(@"                    default:
                         hashCode = 0;
                         break;
                 }
@@ -308,7 +319,4 @@ namespace OneOf
             }
         }
     }");
-	}
-	sb.AppendLine("}");
-	return sb.ToString(); ;
 }

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -332,9 +332,9 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOf<T0, T1> RearrangeFrom( OneOf<T0,T1> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
+        public static OneOf<T0, T1> RearrangeFrom( OneOf<T0, T1> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
 
-        public static OneOf<T0, T1> RearrangeFrom( OneOf<T1,T0> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
+        public static OneOf<T0, T1> RearrangeFrom( OneOf<T1, T0> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
 
 
 #endregion
@@ -604,17 +604,17 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0, T1, T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0, T2, T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1, T0, T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1, T2, T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2, T0, T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
 
 #endregion
@@ -950,53 +950,53 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T1, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T1, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T2, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T2, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T3, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0, T3, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T0, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T0, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T2, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T2, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T3, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1, T3, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T0, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T0, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T1, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T1, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T3, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2, T3, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T0, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T0, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T1, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T1, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T2, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
 
 #endregion
@@ -1400,245 +1400,245 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T2,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T2, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T2,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T2, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T3,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T3, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T3,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T3, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T4,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T4, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T4,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T1, T4, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T1,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T1, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T1,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T1, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T3,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T3, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T3,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T3, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T4,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T4, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T4,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T2, T4, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T1,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T1, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T1,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T1, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T2,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T2, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T2,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T2, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T4,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T4, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T4,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T3, T4, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T1, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T1, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T2, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T2, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T3, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0, T4, T3, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T2,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T2, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T2,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T2, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T3,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T3, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T3,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T3, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T4,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T4, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T4,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T0, T4, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T0,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T0, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T0,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T0, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T3,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T3, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T3,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T3, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T4,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T4, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T4,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T2, T4, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T0,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T0, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T0,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T0, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T2,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T2, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T2,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T2, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T4,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T4, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T4,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T3, T4, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T0, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T0, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T2, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T2, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T3, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1, T4, T3, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T1,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T1, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T1,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T1, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T3,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T3, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T3,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T3, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T4,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T4, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T4,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T0, T4, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T0,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T0, T3, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T0,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T0, T4, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T3,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T3, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T3,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T3, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T4,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T4, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T4,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T1, T4, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T0,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T0, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T0,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T0, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T1,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T1, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T1,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T1, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T4,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T4, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T4,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T3, T4, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T0, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T0, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T1, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T1, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T3, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2, T4, T3, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T1,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T1, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T1,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T1, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T2,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T2, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T2,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T2, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T4,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T4, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T4,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T0, T4, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T0,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T0, T2, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T0,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T0, T4, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T2,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T2, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T2,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T2, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T4,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T4, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T4,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T1, T4, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T0,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T0, T1, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T0,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T0, T4, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T1,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T1, T0, T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T1,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T1, T4, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T4,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T4, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T4,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T2, T4, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T0, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T0, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T1, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T1, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T2, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3, T4, T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T1, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T1, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T2, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T2, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T3, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T0, T3, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T0, T2, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T0, T3, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T2, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T2, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T3, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T1, T3, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T0, T1, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T0, T3, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T1, T0, T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T1, T3, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T3, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T2, T3, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T0, T1, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T0, T2, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T1, T0, T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T1, T2, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T2, T0, T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
 
 #endregion

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -127,6 +127,14 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOf<T0> RearrangeFrom( OneOf<T0> other ) => other.Match< OneOf<T0> >( v0 => v0 );
+
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1> : IOneOf
@@ -321,6 +329,16 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOf<T0, T1> RearrangeFrom( OneOf<T0,T1> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
+
+        public static OneOf<T0, T1> RearrangeFrom( OneOf<T1,T0> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
+
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2> : IOneOf
@@ -583,6 +601,24 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3> : IOneOf
@@ -911,6 +947,60 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T0,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T1,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T2,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
@@ -1307,6 +1397,252 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T2,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T2,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T3,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T3,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T4,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T1,T4,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T1,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T1,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T3,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T3,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T4,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T2,T4,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T1,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T1,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T2,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T2,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T4,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T3,T4,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T0,T4,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T2,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T2,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T3,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T3,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T4,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T0,T4,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T0,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T0,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T3,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T3,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T4,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T2,T4,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T0,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T0,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T2,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T2,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T4,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T3,T4,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T1,T4,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T1,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T1,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T3,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T3,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T4,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T0,T4,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T0,T3,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T0,T4,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T3,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T3,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T4,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T1,T4,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T0,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T0,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T1,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T1,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T4,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T3,T4,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T2,T4,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T1,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T1,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T2,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T2,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T4,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T0,T4,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T0,T2,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T0,T4,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T2,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T2,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T4,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T1,T4,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T0,T1,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T0,T4,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T1,T0,T4> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T1,T4,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T4,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T2,T4,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T3,T4,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T1,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T1,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T2,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T2,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T3,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T0,T3,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T0,T2,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T0,T3,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T2,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T2,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T3,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T1,T3,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T0,T1,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T0,T3,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T1,T0,T3> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T1,T3,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T3,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T2,T3,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T0,T1,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T0,T2,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T1,T0,T2> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T1,T2,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T2,T0,T1> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4,T3,T2,T1,T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -132,6 +132,29 @@ namespace OneOf
 
         public static OneOf<T0> RearrangeFrom( OneOf<T0> other ) => other.Match< OneOf<T0> >( v0 => v0 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1> Extend<T1>() => this.Match< OneOf<T0, T1> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2> Extend<T1, T2>() => this.Match< OneOf<T0, T1, T2> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3> Extend<T1, T2, T3>() => this.Match< OneOf<T0, T1, T2, T3> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3, T4> Extend<T1, T2, T3, T4>() => this.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5> Extend<T1, T2, T3, T4, T5>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T1, T2, T3, T4, T5, T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T1, T2, T3, T4, T5, T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T1, T2, T3, T4, T5, T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
 
 #endregion
 
@@ -336,6 +359,29 @@ namespace OneOf
 
         public static OneOf<T0, T1> RearrangeFrom( OneOf<T1, T0> other ) => other.Match< OneOf<T0, T1> >( v0 => v0, v1 => v1 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2> Extend<T2>() => this.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3> Extend<T2, T3>() => this.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3, T4> Extend<T2, T3, T4>() => this.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5> Extend<T2, T3, T4, T5>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T2, T3, T4, T5, T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T2, T3, T4, T5, T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T2, T3, T4, T5, T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1>( OneOf<T0> smaller ) => smaller.Extend<T1>();
 
 #endregion
 
@@ -616,6 +662,29 @@ namespace OneOf
 
         public static OneOf<T0, T1, T2> RearrangeFrom( OneOf<T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3> Extend<T3>() => this.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOf<T0, T1, T2, T3, T4> Extend<T3, T4>() => this.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5> Extend<T3, T4, T5>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T3, T4, T5, T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T3, T4, T5, T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T3, T4, T5, T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2>( OneOf<T0, T1> smaller ) => smaller.Extend<T2>();
+
+        public static implicit operator OneOf<T0, T1, T2>( OneOf<T0> smaller ) => smaller.Extend<T1, T2>();
 
 #endregion
 
@@ -998,6 +1067,29 @@ namespace OneOf
 
         public static OneOf<T0, T1, T2, T3> RearrangeFrom( OneOf<T3, T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3, T4> Extend<T4>() => this.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5> Extend<T4, T5>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T4, T5, T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T4, T5, T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T4, T5, T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2, T3>( OneOf<T0, T1, T2> smaller ) => smaller.Extend<T3>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3>( OneOf<T0, T1> smaller ) => smaller.Extend<T2, T3>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3>( OneOf<T0> smaller ) => smaller.Extend<T1, T2, T3>();
 
 #endregion
 
@@ -1640,6 +1732,29 @@ namespace OneOf
 
         public static OneOf<T0, T1, T2, T3, T4> RearrangeFrom( OneOf<T4, T3, T2, T1, T0> other ) => other.Match< OneOf<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3, T4, T5> Extend<T5>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T5, T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T5, T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T5, T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>( OneOf<T0, T1, T2, T3> smaller ) => smaller.Extend<T4>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>( OneOf<T0, T1, T2> smaller ) => smaller.Extend<T3, T4>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>( OneOf<T0, T1> smaller ) => smaller.Extend<T2, T3, T4>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4>( OneOf<T0> smaller ) => smaller.Extend<T1, T2, T3, T4>();
 
 #endregion
 
@@ -2109,6 +2224,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6> Extend<T6>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T6, T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T6, T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>( OneOf<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>( OneOf<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>( OneOf<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>( OneOf<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>( OneOf<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5>();
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
@@ -2647,6 +2786,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T7>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6 );
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T7, T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0, T1, T2, T3, T4, T5> smaller ) => smaller.Extend<T6>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5, T6>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5, T6>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5, T6>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5, T6>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>( OneOf<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5, T6>();
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
@@ -3259,6 +3422,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T8>() => this.Match< OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6, v7 => v7 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1, T2, T3, T4, T5, T6> smaller ) => smaller.Extend<T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1, T2, T3, T4, T5> smaller ) => smaller.Extend<T6, T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5, T6, T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5, T6, T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5, T6, T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5, T6, T7>();
+
+        public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>( OneOf<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5, T6, T7>();
+
+#endregion
+
     }
 
     public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf

--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -14,6 +14,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>OneOf</PackageId>
     <Copyright>Harry McIntyre</Copyright>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -316,9 +316,9 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T0,T1> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
+        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T0, T1> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
 
-        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T1,T0> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
+        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T1, T0> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
 
 
 #endregion
@@ -560,17 +560,17 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
-        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
 
 #endregion
@@ -862,53 +862,53 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T1, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T1, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T2, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T2, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T3, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0, T3, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T0, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T0, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T2, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T2, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T3, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1, T3, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T0, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T0, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T1, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T1, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T3, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2, T3, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T0, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T0, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T1, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T1, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T2, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
-        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
 
 #endregion
@@ -1250,245 +1250,245 @@ namespace OneOf
 
 #region Rearrange (not subset)
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T2,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T2, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T2,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T2, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T3,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T3, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T3,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T3, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T4,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T4, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T4,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T1, T4, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T1,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T1, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T1,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T1, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T3,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T3, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T3,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T3, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T4,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T4, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T4,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T2, T4, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T1,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T1, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T1,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T1, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T2,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T2, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T2,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T2, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T4,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T4, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T4,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T3, T4, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T1, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T1, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T2, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T2, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T3, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0, T4, T3, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T2,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T2, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T2,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T2, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T3,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T3, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T3,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T3, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T4,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T4, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T4,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T0, T4, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T0,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T0, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T0,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T0, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T3,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T3, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T3,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T3, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T4,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T4, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T4,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T2, T4, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T0,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T0, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T0,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T0, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T2,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T2, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T2,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T2, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T4,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T4, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T4,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T3, T4, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T0, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T0, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T2, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T2, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T3, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1, T4, T3, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T1,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T1, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T1,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T1, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T3,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T3, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T3,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T3, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T4,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T4, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T4,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T0, T4, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T0,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T0, T3, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T0,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T0, T4, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T3,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T3, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T3,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T3, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T4,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T4, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T4,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T1, T4, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T0,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T0, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T0,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T0, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T1,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T1, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T1,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T1, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T4,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T4, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T4,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T3, T4, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T0, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T0, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T1, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T1, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T3, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2, T4, T3, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T1,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T1, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T1,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T1, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T2,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T2, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T2,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T2, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T4,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T4, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T4,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T0, T4, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T0,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T0, T2, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T0,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T0, T4, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T2,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T2, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T2,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T2, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T4,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T4, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T4,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T1, T4, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T0,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T0, T1, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T0,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T0, T4, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T1,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T1, T0, T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T1,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T1, T4, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T4,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T4, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T4,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T2, T4, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T0, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T0, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T1, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T1, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T2, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3, T4, T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T1, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T1, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T2, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T2, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T3, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T0, T3, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T0, T2, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T0, T3, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T2, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T2, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T3, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T1, T3, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T0, T1, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T0, T3, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T1, T0, T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T1, T3, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T3, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T2, T3, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T0, T1, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T0, T2, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T1, T0, T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T1, T2, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T2, T0, T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
-        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
 
 #endregion

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -130,6 +130,29 @@ namespace OneOf
 
         public static OneOfBase<T0> RearrangeFrom( OneOfBase<T0> other ) => other.Match< OneOfBase<T0> >( v0 => v0 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1> Extend<T1>() => this.Match< OneOfBase<T0, T1> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2> Extend<T1, T2>() => this.Match< OneOfBase<T0, T1, T2> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3> Extend<T1, T2, T3>() => this.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3, T4> Extend<T1, T2, T3, T4>() => this.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5> Extend<T1, T2, T3, T4, T5>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T1, T2, T3, T4, T5, T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T1, T2, T3, T4, T5, T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T1, T2, T3, T4, T5, T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
 
 #endregion
 
@@ -320,6 +343,29 @@ namespace OneOf
 
         public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T1, T0> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2> Extend<T2>() => this.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3> Extend<T2, T3>() => this.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3, T4> Extend<T2, T3, T4>() => this.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5> Extend<T2, T3, T4, T5>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T2, T3, T4, T5, T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T2, T3, T4, T5, T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T2, T3, T4, T5, T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1>( OneOfBase<T0> smaller ) => smaller.Extend<T1>();
 
 #endregion
 
@@ -572,6 +618,29 @@ namespace OneOf
 
         public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3> Extend<T3>() => this.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOfBase<T0, T1, T2, T3, T4> Extend<T3, T4>() => this.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5> Extend<T3, T4, T5>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T3, T4, T5, T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T3, T4, T5, T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T3, T4, T5, T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2>();
+
+        public static implicit operator OneOfBase<T0, T1, T2>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2>();
 
 #endregion
 
@@ -910,6 +979,29 @@ namespace OneOf
 
         public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3, T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3, T4> Extend<T4>() => this.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5> Extend<T4, T5>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T4, T5, T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T4, T5, T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T4, T5, T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3>( OneOfBase<T0, T1, T2> smaller ) => smaller.Extend<T3>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2, T3>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2, T3>();
 
 #endregion
 
@@ -1490,6 +1582,29 @@ namespace OneOf
 
         public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4, T3, T2, T1, T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
 
+#endregion
+
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5> Extend<T5>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T5, T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T5, T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T5, T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>( OneOfBase<T0, T1, T2, T3> smaller ) => smaller.Extend<T4>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>( OneOfBase<T0, T1, T2> smaller ) => smaller.Extend<T3, T4>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2, T3, T4>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2, T3, T4>();
 
 #endregion
 
@@ -1877,6 +1992,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6> Extend<T6>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T6, T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T6, T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>( OneOfBase<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>( OneOfBase<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>( OneOfBase<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5>();
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6> : IOneOf
@@ -2311,6 +2450,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> Extend<T7>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6 );
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T7, T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0, T1, T2, T3, T4, T5> smaller ) => smaller.Extend<T6>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5, T6>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5, T6>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5, T6>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5, T6>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5, T6>();
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
@@ -2795,6 +2958,30 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+#region Extend (Explicit addition of (empty) type arguments)
+
+        public OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> Extend<T8>() => this.Match< OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4, v5 => v5, v6 => v6, v7 => v7 );
+
+#endregion
+
+#region Implicit conversion from subset (without rearranging type arguments)
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1, T2, T3, T4, T5, T6> smaller ) => smaller.Extend<T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1, T2, T3, T4, T5> smaller ) => smaller.Extend<T6, T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1, T2, T3, T4> smaller ) => smaller.Extend<T5, T6, T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1, T2, T3> smaller ) => smaller.Extend<T4, T5, T6, T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1, T2> smaller ) => smaller.Extend<T3, T4, T5, T6, T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0, T1> smaller ) => smaller.Extend<T2, T3, T4, T5, T6, T7>();
+
+        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>( OneOfBase<T0> smaller ) => smaller.Extend<T1, T2, T3, T4, T5, T6, T7>();
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -125,6 +125,14 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOfBase<T0> RearrangeFrom( OneOfBase<T0> other ) => other.Match< OneOfBase<T0> >( v0 => v0 );
+
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1> : IOneOf
@@ -305,6 +313,16 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T0,T1> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
+
+        public static OneOfBase<T0, T1> RearrangeFrom( OneOfBase<T1,T0> other ) => other.Match< OneOfBase<T0, T1> >( v0 => v0, v1 => v1 );
+
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2> : IOneOf
@@ -539,6 +557,24 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+        public static OneOfBase<T0, T1, T2> RearrangeFrom( OneOfBase<T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2> >( v0 => v0, v1 => v1, v2 => v2 );
+
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3> : IOneOf
@@ -823,6 +859,60 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T0,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T1,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T2,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+        public static OneOfBase<T0, T1, T2, T3> RearrangeFrom( OneOfBase<T3,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3 );
+
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4> : IOneOf
@@ -1157,6 +1247,252 @@ namespace OneOf
                 return (hashCode*397) ^ _index;
             }
         }
+
+#region Rearrange (not subset)
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T2,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T2,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T3,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T3,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T4,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T1,T4,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T1,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T1,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T3,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T3,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T4,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T2,T4,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T1,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T1,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T2,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T2,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T4,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T3,T4,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T0,T4,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T2,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T2,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T3,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T3,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T4,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T0,T4,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T0,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T0,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T3,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T3,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T4,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T2,T4,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T0,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T0,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T2,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T2,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T4,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T3,T4,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T1,T4,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T1,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T1,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T3,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T3,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T4,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T0,T4,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T0,T3,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T0,T4,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T3,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T3,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T4,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T1,T4,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T0,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T0,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T1,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T1,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T4,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T3,T4,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T2,T4,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T1,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T1,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T2,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T2,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T4,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T0,T4,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T0,T2,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T0,T4,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T2,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T2,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T4,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T1,T4,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T0,T1,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T0,T4,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T1,T0,T4> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T1,T4,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T4,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T2,T4,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T3,T4,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T1,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T1,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T2,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T2,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T3,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T0,T3,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T0,T2,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T0,T3,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T2,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T2,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T3,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T1,T3,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T0,T1,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T0,T3,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T1,T0,T3> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T1,T3,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T3,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T2,T3,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T0,T1,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T0,T2,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T1,T0,T2> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T1,T2,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T2,T0,T1> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+        public static OneOfBase<T0, T1, T2, T3, T4> RearrangeFrom( OneOfBase<T4,T3,T2,T1,T0> other ) => other.Match< OneOfBase<T0, T1, T2, T3, T4> >( v0 => v0, v1 => v1, v2 => v2, v3 => v3, v4 => v4 );
+
+
+#endregion
+
     }
 
     public class OneOfBase<T0, T1, T2, T3, T4, T5> : IOneOf


### PR DESCRIPTION
I had been hoping to implement compile-time type-safe implicit conversions between "equivalent" and superset `OneOf` values by having `OneOf` implement a new interface `IMaybeHas<T>`, but I was thwarted by the C# compiler preventing open-generic classes from implementing the same interface multiple times with different type-arguments.

...so I fell-back to generating permutations of type-arguments. Because the number of permutations quickly explodes when `n > 5` this is limited to `OneOf<T0>` through `OneOf<T0,T1,T2,T3,T4>`.

This PR is if anyone is interested in it - I'd be flattered if you'd integrate it or had suggestions for improvements.
