### PR TITLE
Fix #66

### DIFF
--- a/OneOf.Extended/OneOf.cs
+++ b/OneOf.Extended/OneOf.cs
@@ -62,6 +62,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -79,7 +81,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -95,7 +96,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -113,7 +113,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -129,7 +128,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -147,7 +145,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -163,7 +160,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -181,7 +177,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -197,7 +192,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -215,7 +209,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -231,7 +224,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(9, value9: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9)
         {
@@ -832,6 +824,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -849,7 +843,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -865,7 +858,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -883,7 +875,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -899,7 +890,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -917,7 +907,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -933,7 +922,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -951,7 +939,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -967,7 +954,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -985,7 +971,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -1002,7 +987,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(9, value9: t);
 
-
         public bool IsT10 => _index == 10;
 
         public T10 AsT10
@@ -1018,7 +1002,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(10, value10: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10)
         {
@@ -1682,6 +1665,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1699,7 +1684,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1715,7 +1699,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1733,7 +1716,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1749,7 +1731,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1767,7 +1748,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1783,7 +1763,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -1801,7 +1780,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -1817,7 +1795,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -1835,7 +1812,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -1851,7 +1827,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -1869,7 +1844,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -1885,7 +1859,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(11, value11: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11)
         {
@@ -2614,6 +2587,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2631,7 +2606,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2647,7 +2621,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2665,7 +2638,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2681,7 +2653,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2699,7 +2670,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2715,7 +2685,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2733,7 +2702,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2749,7 +2717,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -2767,7 +2734,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -2783,7 +2749,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -2801,7 +2766,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -2818,7 +2782,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(11, value11: t);
 
-
         public bool IsT12 => _index == 12;
 
         public T12 AsT12
@@ -2834,7 +2797,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(12, value12: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12)
         {
@@ -3630,6 +3592,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -3647,7 +3611,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -3663,7 +3626,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -3681,7 +3643,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -3697,7 +3658,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -3715,7 +3675,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -3731,7 +3690,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -3749,7 +3707,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -3765,7 +3722,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -3783,7 +3739,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -3799,7 +3754,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -3817,7 +3771,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -3833,7 +3786,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -3851,7 +3803,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -3867,7 +3818,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(13, value13: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13)
         {
@@ -4732,6 +4682,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -4749,7 +4701,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -4765,7 +4716,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -4783,7 +4733,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -4799,7 +4748,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -4817,7 +4765,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -4833,7 +4780,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -4851,7 +4797,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -4867,7 +4812,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -4885,7 +4829,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -4901,7 +4844,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -4919,7 +4861,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -4935,7 +4876,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -4953,7 +4893,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -4970,7 +4909,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(13, value13: t);
 
-
         public bool IsT14 => _index == 14;
 
         public T14 AsT14
@@ -4986,7 +4924,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(14, value14: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14)
         {
@@ -5922,6 +5859,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -5939,7 +5878,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -5955,7 +5893,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -5973,7 +5910,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -5989,7 +5925,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -6007,7 +5942,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -6023,7 +5957,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -6041,7 +5974,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -6057,7 +5989,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -6075,7 +6006,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -6091,7 +6021,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -6109,7 +6038,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -6125,7 +6053,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -6143,7 +6070,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -6159,7 +6085,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -6177,7 +6102,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -6193,7 +6117,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(15, value15: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15)
         {
@@ -7202,6 +7125,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -7219,7 +7144,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -7235,7 +7159,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -7253,7 +7176,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -7269,7 +7191,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -7287,7 +7208,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -7303,7 +7223,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -7321,7 +7240,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -7337,7 +7255,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -7355,7 +7272,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -7371,7 +7287,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -7389,7 +7304,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -7405,7 +7319,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -7423,7 +7336,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -7439,7 +7351,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -7457,7 +7368,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -7474,7 +7384,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(15, value15: t);
 
-
         public bool IsT16 => _index == 16;
 
         public T16 AsT16
@@ -7490,7 +7399,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(16, value16: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16)
         {
@@ -8574,6 +8482,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -8591,7 +8501,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -8607,7 +8516,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -8625,7 +8533,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -8641,7 +8548,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -8659,7 +8565,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -8675,7 +8580,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -8693,7 +8597,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -8709,7 +8612,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -8727,7 +8629,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -8743,7 +8644,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -8761,7 +8661,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -8777,7 +8676,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -8795,7 +8693,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -8811,7 +8708,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -8829,7 +8725,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -8845,7 +8740,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -8863,7 +8757,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -8879,7 +8772,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(17, value17: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17)
         {
@@ -10040,6 +9932,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -10057,7 +9951,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -10073,7 +9966,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -10091,7 +9983,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -10107,7 +9998,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -10125,7 +10015,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -10141,7 +10030,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -10159,7 +10047,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -10175,7 +10062,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -10193,7 +10079,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -10209,7 +10094,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -10227,7 +10111,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -10243,7 +10126,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -10261,7 +10143,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -10277,7 +10158,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -10295,7 +10175,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -10311,7 +10190,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -10329,7 +10207,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -10346,7 +10223,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(17, value17: t);
 
-
         public bool IsT18 => _index == 18;
 
         public T18 AsT18
@@ -10362,7 +10238,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(18, value18: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18)
         {
@@ -11602,6 +11477,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -11619,7 +11496,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -11635,7 +11511,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -11653,7 +11528,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -11669,7 +11543,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -11687,7 +11560,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -11703,7 +11575,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -11721,7 +11592,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -11737,7 +11607,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -11755,7 +11624,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -11771,7 +11639,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -11789,7 +11656,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -11805,7 +11671,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -11823,7 +11688,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -11839,7 +11703,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -11857,7 +11720,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -11873,7 +11735,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -11891,7 +11752,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -11907,7 +11767,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -11925,7 +11784,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -11941,7 +11799,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(19, value19: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19)
         {
@@ -13262,6 +13119,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -13279,7 +13138,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -13295,7 +13153,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -13313,7 +13170,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -13329,7 +13185,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -13347,7 +13202,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -13363,7 +13217,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -13381,7 +13234,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -13397,7 +13249,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -13415,7 +13266,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -13431,7 +13281,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -13449,7 +13298,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -13465,7 +13313,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -13483,7 +13330,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -13499,7 +13345,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -13517,7 +13362,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -13533,7 +13377,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -13551,7 +13394,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -13567,7 +13409,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -13585,7 +13426,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -13602,7 +13442,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(19, value19: t);
 
-
         public bool IsT20 => _index == 20;
 
         public T20 AsT20
@@ -13618,7 +13457,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(20, value20: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20)
         {
@@ -15022,6 +14860,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -15039,7 +14879,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -15055,7 +14894,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -15073,7 +14911,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -15089,7 +14926,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -15107,7 +14943,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -15123,7 +14958,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -15141,7 +14975,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -15157,7 +14990,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -15175,7 +15007,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -15191,7 +15022,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -15209,7 +15039,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -15225,7 +15054,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -15243,7 +15071,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -15259,7 +15086,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -15277,7 +15103,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -15293,7 +15118,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -15311,7 +15135,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -15327,7 +15150,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -15345,7 +15167,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -15361,7 +15182,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -15379,7 +15199,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -15395,7 +15214,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(21, value21: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21)
         {
@@ -16884,6 +16702,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -16901,7 +16721,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -16917,7 +16736,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -16935,7 +16753,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -16951,7 +16768,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -16969,7 +16785,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -16985,7 +16800,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -17003,7 +16817,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -17019,7 +16832,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -17037,7 +16849,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -17053,7 +16864,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -17071,7 +16881,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -17087,7 +16896,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -17105,7 +16913,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -17121,7 +16928,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -17139,7 +16945,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -17155,7 +16960,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -17173,7 +16977,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -17189,7 +16992,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -17207,7 +17009,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -17223,7 +17024,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -17241,7 +17041,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -17258,7 +17057,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(21, value21: t);
 
-
         public bool IsT22 => _index == 22;
 
         public T22 AsT22
@@ -17274,7 +17072,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(22, value22: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22)
         {
@@ -18850,6 +18647,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -18867,7 +18666,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -18883,7 +18681,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -18901,7 +18698,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -18917,7 +18713,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -18935,7 +18730,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -18951,7 +18745,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -18969,7 +18762,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -18985,7 +18777,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -19003,7 +18794,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -19019,7 +18809,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -19037,7 +18826,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -19053,7 +18841,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -19071,7 +18858,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -19087,7 +18873,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -19105,7 +18890,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -19121,7 +18905,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -19139,7 +18922,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -19155,7 +18937,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -19173,7 +18954,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -19189,7 +18969,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -19207,7 +18986,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -19223,7 +19001,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -19241,7 +19018,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -19257,7 +19033,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(23, value23: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23)
         {
@@ -20922,6 +20697,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -20939,7 +20716,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -20955,7 +20731,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -20973,7 +20748,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -20989,7 +20763,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -21007,7 +20780,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -21023,7 +20795,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -21041,7 +20812,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -21057,7 +20827,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -21075,7 +20844,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -21091,7 +20859,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -21109,7 +20876,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -21125,7 +20891,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -21143,7 +20908,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -21159,7 +20923,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -21177,7 +20940,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -21193,7 +20955,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -21211,7 +20972,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -21227,7 +20987,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -21245,7 +21004,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -21261,7 +21019,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -21279,7 +21036,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -21295,7 +21051,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -21313,7 +21068,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -21330,7 +21084,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(23, value23: t);
 
-
         public bool IsT24 => _index == 24;
 
         public T24 AsT24
@@ -21346,7 +21099,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(24, value24: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24)
         {
@@ -23102,6 +22854,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -23119,7 +22873,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -23135,7 +22888,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -23153,7 +22905,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -23169,7 +22920,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -23187,7 +22937,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -23203,7 +22952,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -23221,7 +22969,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -23237,7 +22984,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -23255,7 +23001,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -23271,7 +23016,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -23289,7 +23033,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -23305,7 +23048,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -23323,7 +23065,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -23339,7 +23080,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -23357,7 +23097,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -23373,7 +23112,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -23391,7 +23129,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -23407,7 +23144,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -23425,7 +23161,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -23441,7 +23176,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -23459,7 +23193,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -23475,7 +23208,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -23493,7 +23225,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -23509,7 +23240,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -23527,7 +23257,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -23543,7 +23272,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(25, value25: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25)
         {
@@ -25392,6 +25120,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -25409,7 +25139,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -25425,7 +25154,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -25443,7 +25171,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -25459,7 +25186,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -25477,7 +25203,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -25493,7 +25218,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -25511,7 +25235,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -25527,7 +25250,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -25545,7 +25267,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -25561,7 +25282,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -25579,7 +25299,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -25595,7 +25314,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -25613,7 +25331,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -25629,7 +25346,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -25647,7 +25363,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -25663,7 +25378,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -25681,7 +25395,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -25697,7 +25410,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -25715,7 +25427,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -25731,7 +25442,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -25749,7 +25459,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -25765,7 +25474,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -25783,7 +25491,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -25799,7 +25506,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -25817,7 +25523,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -25834,7 +25539,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(25, value25: t);
 
-
         public bool IsT26 => _index == 26;
 
         public T26 AsT26
@@ -25850,7 +25554,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(26, value26: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26)
         {
@@ -27794,6 +27497,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -27811,7 +27516,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -27827,7 +27531,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -27845,7 +27548,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -27861,7 +27563,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -27879,7 +27580,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -27895,7 +27595,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -27913,7 +27612,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -27929,7 +27627,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -27947,7 +27644,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -27963,7 +27659,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -27981,7 +27676,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -27997,7 +27691,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -28015,7 +27708,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -28031,7 +27723,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -28049,7 +27740,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -28065,7 +27755,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -28083,7 +27772,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -28099,7 +27787,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -28117,7 +27804,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -28133,7 +27819,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -28151,7 +27836,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -28167,7 +27851,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -28185,7 +27868,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -28201,7 +27883,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -28219,7 +27900,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -28235,7 +27915,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -28253,7 +27932,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(26, value26: t);
 
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -28269,7 +27947,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(27, value27: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27)
         {
@@ -30310,6 +29987,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -30327,7 +30006,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -30343,7 +30021,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -30361,7 +30038,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -30377,7 +30053,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -30395,7 +30070,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -30411,7 +30085,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -30429,7 +30102,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -30445,7 +30117,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -30463,7 +30134,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -30479,7 +30149,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -30497,7 +30166,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -30513,7 +30181,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -30531,7 +30198,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -30547,7 +30213,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -30565,7 +30230,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -30581,7 +30245,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -30599,7 +30262,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -30615,7 +30277,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -30633,7 +30294,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -30649,7 +30309,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -30667,7 +30326,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -30683,7 +30341,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -30701,7 +30358,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -30717,7 +30373,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -30735,7 +30390,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -30751,7 +30405,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -30769,7 +30422,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(26, value26: t);
 
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -30786,7 +30438,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(27, value27: t);
 
-
         public bool IsT28 => _index == 28;
 
         public T28 AsT28
@@ -30802,7 +30453,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(28, value28: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28)
         {
@@ -32942,6 +32592,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -32959,7 +32611,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -32975,7 +32626,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -32993,7 +32643,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -33009,7 +32658,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -33027,7 +32675,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -33043,7 +32690,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -33061,7 +32707,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -33077,7 +32722,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -33095,7 +32739,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -33111,7 +32754,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -33129,7 +32771,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -33145,7 +32786,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -33163,7 +32803,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -33179,7 +32818,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -33197,7 +32835,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -33213,7 +32850,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -33231,7 +32867,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -33247,7 +32882,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -33265,7 +32899,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -33281,7 +32914,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -33299,7 +32931,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -33315,7 +32946,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -33333,7 +32963,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -33349,7 +32978,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -33367,7 +32995,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -33383,7 +33010,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -33401,7 +33027,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(26, value26: t);
 
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -33417,7 +33042,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -33435,7 +33059,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(28, value28: t);
 
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -33451,7 +33074,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T29 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(29, value29: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29)
         {
@@ -35692,6 +35314,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -35709,7 +35333,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -35725,7 +35348,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -35743,7 +35365,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -35759,7 +35380,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -35777,7 +35397,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -35793,7 +35412,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -35811,7 +35429,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -35827,7 +35444,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -35845,7 +35461,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -35861,7 +35476,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -35879,7 +35493,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -35895,7 +35508,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -35913,7 +35525,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -35929,7 +35540,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -35947,7 +35557,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -35963,7 +35572,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -35981,7 +35589,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -35997,7 +35604,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -36015,7 +35621,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -36031,7 +35636,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -36049,7 +35653,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -36065,7 +35668,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -36083,7 +35685,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -36099,7 +35700,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -36117,7 +35717,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -36133,7 +35732,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -36151,7 +35749,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(26, value26: t);
 
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -36167,7 +35764,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -36185,7 +35781,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(28, value28: t);
 
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -36202,7 +35797,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T29 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(29, value29: t);
 
-
         public bool IsT30 => _index == 30;
 
         public T30 AsT30
@@ -36218,7 +35812,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T30 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(30, value30: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30)
         {
@@ -38562,6 +38155,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -38579,7 +38174,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -38595,7 +38189,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -38613,7 +38206,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -38629,7 +38221,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -38647,7 +38238,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -38663,7 +38253,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -38681,7 +38270,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -38697,7 +38285,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -38715,7 +38302,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(8, value8: t);
 
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -38731,7 +38317,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T9 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -38749,7 +38334,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T10 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(10, value10: t);
 
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -38765,7 +38349,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T11 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -38783,7 +38366,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T12 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(12, value12: t);
 
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -38799,7 +38381,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T13 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -38817,7 +38398,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T14 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(14, value14: t);
 
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -38833,7 +38413,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T15 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -38851,7 +38430,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T16 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(16, value16: t);
 
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -38867,7 +38445,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T17 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -38885,7 +38462,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T18 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(18, value18: t);
 
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -38901,7 +38477,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T19 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -38919,7 +38494,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T20 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(20, value20: t);
 
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -38935,7 +38509,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T21 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -38953,7 +38526,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T22 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(22, value22: t);
 
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -38969,7 +38541,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T23 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -38987,7 +38558,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T24 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(24, value24: t);
 
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -39003,7 +38573,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T25 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -39021,7 +38590,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T26 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(26, value26: t);
 
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -39037,7 +38605,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T27 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -39055,7 +38622,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T28 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(28, value28: t);
 
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -39071,7 +38637,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T29 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(29, value29: t);
-
 
         public bool IsT30 => _index == 30;
 
@@ -39089,7 +38654,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T30 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(30, value30: t);
 
-
         public bool IsT31 => _index == 31;
 
         public T31 AsT31
@@ -39105,7 +38669,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T31 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(31, value31: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30, Action<T31> f31)
         {

--- a/OneOf.Extended/OneOfBase.cs
+++ b/OneOf.Extended/OneOfBase.cs
@@ -16,83 +16,99 @@ namespace OneOf
         readonly T9 _value9;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>.");
         }
 
         public object Value
@@ -126,6 +142,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -141,9 +159,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -157,9 +172,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -175,9 +187,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -191,9 +200,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -209,9 +215,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -225,9 +228,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -243,9 +243,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -259,9 +256,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -277,9 +271,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -293,9 +284,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(9, value9: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9)
         {
@@ -601,90 +589,107 @@ namespace OneOf
         readonly T10 _value10;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>.");
         }
 
         public object Value
@@ -720,6 +725,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -735,9 +742,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -751,9 +755,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -769,9 +770,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -785,9 +783,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -803,9 +798,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -819,9 +811,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -837,9 +826,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -853,9 +839,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -871,9 +854,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -888,9 +868,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(9, value9: t);
-
-
         public bool IsT10 => _index == 10;
 
         public T10 AsT10
@@ -904,9 +881,6 @@ namespace OneOf
                 return _value10;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(10, value10: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10)
         {
@@ -1236,97 +1210,115 @@ namespace OneOf
         readonly T11 _value11;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>.");
         }
 
         public object Value
@@ -1364,6 +1356,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1379,9 +1373,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1395,9 +1386,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1413,9 +1401,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1429,9 +1414,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1447,9 +1429,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1463,9 +1442,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -1481,9 +1457,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -1497,9 +1470,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -1515,9 +1485,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -1531,9 +1498,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -1549,9 +1513,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -1565,9 +1526,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(11, value11: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11)
         {
@@ -1921,104 +1879,123 @@ namespace OneOf
         readonly T12 _value12;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>.");
         }
 
         public object Value
@@ -2058,6 +2035,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2073,9 +2052,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2089,9 +2065,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2107,9 +2080,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2123,9 +2093,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2141,9 +2108,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2157,9 +2121,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2175,9 +2136,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2191,9 +2149,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -2209,9 +2164,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -2225,9 +2177,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -2243,9 +2192,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -2260,9 +2206,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(11, value11: t);
-
-
         public bool IsT12 => _index == 12;
 
         public T12 AsT12
@@ -2276,9 +2219,6 @@ namespace OneOf
                 return _value12;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(12, value12: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12)
         {
@@ -2656,111 +2596,131 @@ namespace OneOf
         readonly T13 _value13;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>.");
         }
 
         public object Value
@@ -2802,6 +2762,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2817,9 +2779,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2833,9 +2792,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2851,9 +2807,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2867,9 +2820,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2885,9 +2835,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2901,9 +2848,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2919,9 +2863,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2935,9 +2876,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -2953,9 +2891,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -2969,9 +2904,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -2987,9 +2919,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -3003,9 +2932,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -3021,9 +2947,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -3037,9 +2960,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(13, value13: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13)
         {
@@ -3441,118 +3361,139 @@ namespace OneOf
         readonly T14 _value14;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>.");
         }
 
         public object Value
@@ -3596,6 +3537,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -3611,9 +3554,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -3627,9 +3567,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -3645,9 +3582,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -3661,9 +3595,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -3679,9 +3610,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -3695,9 +3623,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -3713,9 +3638,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -3729,9 +3651,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -3747,9 +3666,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -3763,9 +3679,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -3781,9 +3694,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -3797,9 +3707,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -3815,9 +3722,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -3832,9 +3736,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(13, value13: t);
-
-
         public bool IsT14 => _index == 14;
 
         public T14 AsT14
@@ -3848,9 +3749,6 @@ namespace OneOf
                 return _value14;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(14, value14: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14)
         {
@@ -4276,125 +4174,147 @@ namespace OneOf
         readonly T15 _value15;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>.");
         }
 
         public object Value
@@ -4440,6 +4360,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -4455,9 +4377,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -4471,9 +4390,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -4489,9 +4405,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -4505,9 +4418,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -4523,9 +4433,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -4539,9 +4446,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -4557,9 +4461,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -4573,9 +4474,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -4591,9 +4489,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -4607,9 +4502,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -4625,9 +4517,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -4641,9 +4530,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -4659,9 +4545,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -4675,9 +4558,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -4693,9 +4573,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -4709,9 +4586,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(15, value15: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15)
         {
@@ -5161,132 +5035,155 @@ namespace OneOf
         readonly T16 _value16;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>.");
         }
 
         public object Value
@@ -5334,6 +5231,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -5349,9 +5248,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -5365,9 +5261,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -5383,9 +5276,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -5399,9 +5289,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -5417,9 +5304,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -5433,9 +5317,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -5451,9 +5332,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -5467,9 +5345,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -5485,9 +5360,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -5501,9 +5373,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -5519,9 +5388,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -5535,9 +5401,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -5553,9 +5416,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -5569,9 +5429,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -5587,9 +5444,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -5604,9 +5458,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(15, value15: t);
-
-
         public bool IsT16 => _index == 16;
 
         public T16 AsT16
@@ -5620,9 +5471,6 @@ namespace OneOf
                 return _value16;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(16, value16: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16)
         {
@@ -6096,139 +5944,163 @@ namespace OneOf
         readonly T17 _value17;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>.");
         }
 
         public object Value
@@ -6278,6 +6150,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -6293,9 +6167,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -6309,9 +6180,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -6327,9 +6195,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -6343,9 +6208,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -6361,9 +6223,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -6377,9 +6236,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -6395,9 +6251,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -6411,9 +6264,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -6429,9 +6279,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -6445,9 +6292,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -6463,9 +6307,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -6479,9 +6320,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -6497,9 +6335,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -6513,9 +6348,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -6531,9 +6363,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -6547,9 +6376,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -6565,9 +6391,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -6581,9 +6404,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(17, value17: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17)
         {
@@ -7081,146 +6901,171 @@ namespace OneOf
         readonly T18 _value18;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>.");
         }
 
         public object Value
@@ -7272,6 +7117,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -7287,9 +7134,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -7303,9 +7147,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -7321,9 +7162,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -7337,9 +7175,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -7355,9 +7190,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -7371,9 +7203,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -7389,9 +7218,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -7405,9 +7231,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -7423,9 +7246,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -7439,9 +7259,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -7457,9 +7274,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -7473,9 +7287,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -7491,9 +7302,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -7507,9 +7315,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -7525,9 +7330,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -7541,9 +7343,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -7559,9 +7358,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -7576,9 +7372,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(17, value17: t);
-
-
         public bool IsT18 => _index == 18;
 
         public T18 AsT18
@@ -7592,9 +7385,6 @@ namespace OneOf
                 return _value18;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(18, value18: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18)
         {
@@ -8116,153 +7906,179 @@ namespace OneOf
         readonly T19 _value19;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>.");
         }
 
         public object Value
@@ -8316,6 +8132,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -8331,9 +8149,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -8347,9 +8162,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -8365,9 +8177,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -8381,9 +8190,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -8399,9 +8205,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -8415,9 +8218,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -8433,9 +8233,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -8449,9 +8246,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -8467,9 +8261,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -8483,9 +8274,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -8501,9 +8289,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -8517,9 +8302,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -8535,9 +8317,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -8551,9 +8330,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -8569,9 +8345,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -8585,9 +8358,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -8603,9 +8373,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -8619,9 +8386,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -8637,9 +8401,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -8653,9 +8414,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(19, value19: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19)
         {
@@ -9201,160 +8959,187 @@ namespace OneOf
         readonly T20 _value20;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>.");
         }
 
         public object Value
@@ -9410,6 +9195,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -9425,9 +9212,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -9441,9 +9225,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -9459,9 +9240,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -9475,9 +9253,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -9493,9 +9268,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -9509,9 +9281,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -9527,9 +9296,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -9543,9 +9309,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -9561,9 +9324,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -9577,9 +9337,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -9595,9 +9352,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -9611,9 +9365,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -9629,9 +9380,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -9645,9 +9393,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -9663,9 +9408,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -9679,9 +9421,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -9697,9 +9436,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -9713,9 +9449,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -9731,9 +9464,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -9748,9 +9478,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(19, value19: t);
-
-
         public bool IsT20 => _index == 20;
 
         public T20 AsT20
@@ -9764,9 +9491,6 @@ namespace OneOf
                 return _value20;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(20, value20: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20)
         {
@@ -10336,167 +10060,195 @@ namespace OneOf
         readonly T21 _value21;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>.");
         }
 
         public object Value
@@ -10554,6 +10306,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -10569,9 +10323,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -10585,9 +10336,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -10603,9 +10351,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -10619,9 +10364,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -10637,9 +10379,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -10653,9 +10392,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -10671,9 +10407,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -10687,9 +10420,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -10705,9 +10435,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -10721,9 +10448,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -10739,9 +10463,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -10755,9 +10476,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -10773,9 +10491,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -10789,9 +10504,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -10807,9 +10519,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -10823,9 +10532,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -10841,9 +10547,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -10857,9 +10560,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -10875,9 +10575,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -10891,9 +10588,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -10909,9 +10603,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -10925,9 +10616,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(21, value21: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21)
         {
@@ -11521,174 +11209,203 @@ namespace OneOf
         readonly T22 _value22;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>.");
         }
 
         public object Value
@@ -11748,6 +11465,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -11763,9 +11482,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -11779,9 +11495,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -11797,9 +11510,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -11813,9 +11523,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -11831,9 +11538,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -11847,9 +11551,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -11865,9 +11566,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -11881,9 +11579,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -11899,9 +11594,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -11915,9 +11607,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -11933,9 +11622,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -11949,9 +11635,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -11967,9 +11650,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -11983,9 +11663,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -12001,9 +11678,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -12017,9 +11691,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -12035,9 +11706,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -12051,9 +11719,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -12069,9 +11734,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -12085,9 +11747,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -12103,9 +11762,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -12120,9 +11776,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(21, value21: t);
-
-
         public bool IsT22 => _index == 22;
 
         public T22 AsT22
@@ -12136,9 +11789,6 @@ namespace OneOf
                 return _value22;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>(22, value22: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22)
         {
@@ -12756,181 +12406,211 @@ namespace OneOf
         readonly T23 _value23;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>.");
         }
 
         public object Value
@@ -12992,6 +12672,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -13007,9 +12689,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -13023,9 +12702,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -13041,9 +12717,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -13057,9 +12730,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -13075,9 +12745,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -13091,9 +12758,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -13109,9 +12773,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -13125,9 +12786,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -13143,9 +12801,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -13159,9 +12814,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -13177,9 +12829,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -13193,9 +12842,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -13211,9 +12857,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -13227,9 +12870,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -13245,9 +12885,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -13261,9 +12898,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -13279,9 +12913,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -13295,9 +12926,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -13313,9 +12941,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -13329,9 +12954,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -13347,9 +12969,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -13363,9 +12982,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -13381,9 +12997,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -13397,9 +13010,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23>(23, value23: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23)
         {
@@ -14041,188 +13651,219 @@ namespace OneOf
         readonly T24 _value24;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>.");
         }
 
         public object Value
@@ -14286,6 +13927,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -14301,9 +13944,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -14317,9 +13957,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -14335,9 +13972,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -14351,9 +13985,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -14369,9 +14000,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -14385,9 +14013,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -14403,9 +14028,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -14419,9 +14041,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -14437,9 +14056,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -14453,9 +14069,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -14471,9 +14084,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -14487,9 +14097,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -14505,9 +14112,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -14521,9 +14125,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -14539,9 +14140,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -14555,9 +14153,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -14573,9 +14168,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -14589,9 +14181,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -14607,9 +14196,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -14623,9 +14209,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -14641,9 +14224,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -14657,9 +14237,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -14675,9 +14252,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -14692,9 +14266,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(23, value23: t);
-
-
         public bool IsT24 => _index == 24;
 
         public T24 AsT24
@@ -14708,9 +14279,6 @@ namespace OneOf
                 return _value24;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24>(24, value24: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24)
         {
@@ -15376,195 +14944,227 @@ namespace OneOf
         readonly T25 _value25;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>.");
         }
 
         public object Value
@@ -15630,6 +15230,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -15645,9 +15247,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -15661,9 +15260,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -15679,9 +15275,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -15695,9 +15288,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -15713,9 +15303,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -15729,9 +15316,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -15747,9 +15331,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -15763,9 +15344,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -15781,9 +15359,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -15797,9 +15372,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -15815,9 +15387,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -15831,9 +15400,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -15849,9 +15415,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -15865,9 +15428,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -15883,9 +15443,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -15899,9 +15456,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -15917,9 +15471,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -15933,9 +15484,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -15951,9 +15499,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -15967,9 +15512,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -15985,9 +15527,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -16001,9 +15540,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -16019,9 +15555,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -16035,9 +15568,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -16053,9 +15583,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -16069,9 +15596,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25>(25, value25: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25)
         {
@@ -16761,202 +16285,235 @@ namespace OneOf
         readonly T26 _value26;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>.");
         }
 
         public object Value
@@ -17024,6 +16581,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -17039,9 +16598,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -17055,9 +16611,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -17073,9 +16626,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -17089,9 +16639,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -17107,9 +16654,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -17123,9 +16667,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -17141,9 +16682,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -17157,9 +16695,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -17175,9 +16710,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -17191,9 +16723,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -17209,9 +16738,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -17225,9 +16751,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -17243,9 +16766,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -17259,9 +16779,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -17277,9 +16794,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -17293,9 +16807,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -17311,9 +16822,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -17327,9 +16835,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -17345,9 +16850,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -17361,9 +16863,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -17379,9 +16878,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -17395,9 +16891,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -17413,9 +16906,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -17429,9 +16919,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -17447,9 +16934,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -17464,9 +16948,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(25, value25: t);
-
-
         public bool IsT26 => _index == 26;
 
         public T26 AsT26
@@ -17480,9 +16961,6 @@ namespace OneOf
                 return _value26;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26>(26, value26: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26)
         {
@@ -18196,209 +17674,243 @@ namespace OneOf
         readonly T27 _value27;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26), T27 value27 = default(T27))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
-            _value27 = value27;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                case 27: _value27 = input.AsT27; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
             if (this is T27)
             {
                 _index = 27;
                 _value27 = (T27)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>.");
         }
 
         public object Value
@@ -18468,6 +17980,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -18483,9 +17997,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -18499,9 +18010,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -18517,9 +18025,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -18533,9 +18038,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -18551,9 +18053,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -18567,9 +18066,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -18585,9 +18081,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -18601,9 +18094,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -18619,9 +18109,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -18635,9 +18122,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -18653,9 +18137,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -18669,9 +18150,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -18687,9 +18165,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -18703,9 +18178,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -18721,9 +18193,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -18737,9 +18206,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -18755,9 +18221,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -18771,9 +18234,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -18789,9 +18249,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -18805,9 +18262,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -18823,9 +18277,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -18839,9 +18290,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -18857,9 +18305,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -18873,9 +18318,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -18891,9 +18333,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -18907,9 +18346,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -18925,9 +18361,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(26, value26: t);
-
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -18941,9 +18374,6 @@ namespace OneOf
                 return _value27;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(T27 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27>(27, value27: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27)
         {
@@ -19681,216 +19111,251 @@ namespace OneOf
         readonly T28 _value28;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26), T27 value27 = default(T27), T28 value28 = default(T28))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
-            _value27 = value27;
-            _value28 = value28;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                case 27: _value27 = input.AsT27; break;
+                case 28: _value28 = input.AsT28; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
             if (this is T27)
             {
                 _index = 27;
                 _value27 = (T27)(object)this;
                 return;
             }
+
             if (this is T28)
             {
                 _index = 28;
                 _value28 = (T28)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>.");
         }
 
         public object Value
@@ -19962,6 +19427,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -19977,9 +19444,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -19993,9 +19457,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -20011,9 +19472,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -20027,9 +19485,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -20045,9 +19500,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -20061,9 +19513,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -20079,9 +19528,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -20095,9 +19541,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -20113,9 +19556,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -20129,9 +19569,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -20147,9 +19584,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -20163,9 +19597,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -20181,9 +19612,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -20197,9 +19625,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -20215,9 +19640,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -20231,9 +19653,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -20249,9 +19668,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -20265,9 +19681,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -20283,9 +19696,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -20299,9 +19709,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -20317,9 +19724,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -20333,9 +19737,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -20351,9 +19752,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -20367,9 +19765,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -20385,9 +19780,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -20401,9 +19793,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -20419,9 +19808,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(26, value26: t);
-
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -20436,9 +19822,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T27 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(27, value27: t);
-
-
         public bool IsT28 => _index == 28;
 
         public T28 AsT28
@@ -20452,9 +19835,6 @@ namespace OneOf
                 return _value28;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(T28 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28>(28, value28: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28)
         {
@@ -21216,223 +20596,259 @@ namespace OneOf
         readonly T29 _value29;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26), T27 value27 = default(T27), T28 value28 = default(T28), T29 value29 = default(T29))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
-            _value27 = value27;
-            _value28 = value28;
-            _value29 = value29;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                case 27: _value27 = input.AsT27; break;
+                case 28: _value28 = input.AsT28; break;
+                case 29: _value29 = input.AsT29; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
             if (this is T27)
             {
                 _index = 27;
                 _value27 = (T27)(object)this;
                 return;
             }
+
             if (this is T28)
             {
                 _index = 28;
                 _value28 = (T28)(object)this;
                 return;
             }
+
             if (this is T29)
             {
                 _index = 29;
                 _value29 = (T29)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>.");
         }
 
         public object Value
@@ -21506,6 +20922,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -21521,9 +20939,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -21537,9 +20952,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -21555,9 +20967,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -21571,9 +20980,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -21589,9 +20995,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -21605,9 +21008,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -21623,9 +21023,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -21639,9 +21036,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -21657,9 +21051,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -21673,9 +21064,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -21691,9 +21079,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -21707,9 +21092,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -21725,9 +21107,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -21741,9 +21120,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -21759,9 +21135,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -21775,9 +21148,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -21793,9 +21163,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -21809,9 +21176,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -21827,9 +21191,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -21843,9 +21204,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -21861,9 +21219,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -21877,9 +21232,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -21895,9 +21247,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -21911,9 +21260,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -21929,9 +21275,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -21945,9 +21288,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -21963,9 +21303,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(26, value26: t);
-
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -21979,9 +21316,6 @@ namespace OneOf
                 return _value27;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T27 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -21997,9 +21331,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T28 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(28, value28: t);
-
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -22013,9 +21344,6 @@ namespace OneOf
                 return _value29;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(T29 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29>(29, value29: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29)
         {
@@ -22801,230 +22129,267 @@ namespace OneOf
         readonly T30 _value30;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26), T27 value27 = default(T27), T28 value28 = default(T28), T29 value29 = default(T29), T30 value30 = default(T30))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
-            _value27 = value27;
-            _value28 = value28;
-            _value29 = value29;
-            _value30 = value30;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                case 27: _value27 = input.AsT27; break;
+                case 28: _value28 = input.AsT28; break;
+                case 29: _value29 = input.AsT29; break;
+                case 30: _value30 = input.AsT30; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
             if (this is T27)
             {
                 _index = 27;
                 _value27 = (T27)(object)this;
                 return;
             }
+
             if (this is T28)
             {
                 _index = 28;
                 _value28 = (T28)(object)this;
                 return;
             }
+
             if (this is T29)
             {
                 _index = 29;
                 _value29 = (T29)(object)this;
                 return;
             }
+
             if (this is T30)
             {
                 _index = 30;
                 _value30 = (T30)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>.");
         }
 
         public object Value
@@ -23100,6 +22465,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -23115,9 +22482,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -23131,9 +22495,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -23149,9 +22510,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -23165,9 +22523,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -23183,9 +22538,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -23199,9 +22551,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -23217,9 +22566,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -23233,9 +22579,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -23251,9 +22594,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -23267,9 +22607,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -23285,9 +22622,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -23301,9 +22635,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -23319,9 +22650,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -23335,9 +22663,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -23353,9 +22678,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -23369,9 +22691,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -23387,9 +22706,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -23403,9 +22719,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -23421,9 +22734,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -23437,9 +22747,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -23455,9 +22762,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -23471,9 +22775,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -23489,9 +22790,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -23505,9 +22803,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -23523,9 +22818,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -23539,9 +22831,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -23557,9 +22846,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(26, value26: t);
-
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -23573,9 +22859,6 @@ namespace OneOf
                 return _value27;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T27 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -23591,9 +22874,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T28 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(28, value28: t);
-
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -23608,9 +22888,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T29 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(29, value29: t);
-
-
         public bool IsT30 => _index == 30;
 
         public T30 AsT30
@@ -23624,9 +22901,6 @@ namespace OneOf
                 return _value30;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(T30 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30>(30, value30: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30)
         {
@@ -24436,237 +23710,275 @@ namespace OneOf
         readonly T31 _value31;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8), T9 value9 = default(T9), T10 value10 = default(T10), T11 value11 = default(T11), T12 value12 = default(T12), T13 value13 = default(T13), T14 value14 = default(T14), T15 value15 = default(T15), T16 value16 = default(T16), T17 value17 = default(T17), T18 value18 = default(T18), T19 value19 = default(T19), T20 value20 = default(T20), T21 value21 = default(T21), T22 value22 = default(T22), T23 value23 = default(T23), T24 value24 = default(T24), T25 value25 = default(T25), T26 value26 = default(T26), T27 value27 = default(T27), T28 value28 = default(T28), T29 value29 = default(T29), T30 value30 = default(T30), T31 value31 = default(T31))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
-            _value9 = value9;
-            _value10 = value10;
-            _value11 = value11;
-            _value12 = value12;
-            _value13 = value13;
-            _value14 = value14;
-            _value15 = value15;
-            _value16 = value16;
-            _value17 = value17;
-            _value18 = value18;
-            _value19 = value19;
-            _value20 = value20;
-            _value21 = value21;
-            _value22 = value22;
-            _value23 = value23;
-            _value24 = value24;
-            _value25 = value25;
-            _value26 = value26;
-            _value27 = value27;
-            _value28 = value28;
-            _value29 = value29;
-            _value30 = value30;
-            _value31 = value31;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                case 9: _value9 = input.AsT9; break;
+                case 10: _value10 = input.AsT10; break;
+                case 11: _value11 = input.AsT11; break;
+                case 12: _value12 = input.AsT12; break;
+                case 13: _value13 = input.AsT13; break;
+                case 14: _value14 = input.AsT14; break;
+                case 15: _value15 = input.AsT15; break;
+                case 16: _value16 = input.AsT16; break;
+                case 17: _value17 = input.AsT17; break;
+                case 18: _value18 = input.AsT18; break;
+                case 19: _value19 = input.AsT19; break;
+                case 20: _value20 = input.AsT20; break;
+                case 21: _value21 = input.AsT21; break;
+                case 22: _value22 = input.AsT22; break;
+                case 23: _value23 = input.AsT23; break;
+                case 24: _value24 = input.AsT24; break;
+                case 25: _value25 = input.AsT25; break;
+                case 26: _value26 = input.AsT26; break;
+                case 27: _value27 = input.AsT27; break;
+                case 28: _value28 = input.AsT28; break;
+                case 29: _value29 = input.AsT29; break;
+                case 30: _value30 = input.AsT30; break;
+                case 31: _value31 = input.AsT31; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
             if (this is T9)
             {
                 _index = 9;
                 _value9 = (T9)(object)this;
                 return;
             }
+
             if (this is T10)
             {
                 _index = 10;
                 _value10 = (T10)(object)this;
                 return;
             }
+
             if (this is T11)
             {
                 _index = 11;
                 _value11 = (T11)(object)this;
                 return;
             }
+
             if (this is T12)
             {
                 _index = 12;
                 _value12 = (T12)(object)this;
                 return;
             }
+
             if (this is T13)
             {
                 _index = 13;
                 _value13 = (T13)(object)this;
                 return;
             }
+
             if (this is T14)
             {
                 _index = 14;
                 _value14 = (T14)(object)this;
                 return;
             }
+
             if (this is T15)
             {
                 _index = 15;
                 _value15 = (T15)(object)this;
                 return;
             }
+
             if (this is T16)
             {
                 _index = 16;
                 _value16 = (T16)(object)this;
                 return;
             }
+
             if (this is T17)
             {
                 _index = 17;
                 _value17 = (T17)(object)this;
                 return;
             }
+
             if (this is T18)
             {
                 _index = 18;
                 _value18 = (T18)(object)this;
                 return;
             }
+
             if (this is T19)
             {
                 _index = 19;
                 _value19 = (T19)(object)this;
                 return;
             }
+
             if (this is T20)
             {
                 _index = 20;
                 _value20 = (T20)(object)this;
                 return;
             }
+
             if (this is T21)
             {
                 _index = 21;
                 _value21 = (T21)(object)this;
                 return;
             }
+
             if (this is T22)
             {
                 _index = 22;
                 _value22 = (T22)(object)this;
                 return;
             }
+
             if (this is T23)
             {
                 _index = 23;
                 _value23 = (T23)(object)this;
                 return;
             }
+
             if (this is T24)
             {
                 _index = 24;
                 _value24 = (T24)(object)this;
                 return;
             }
+
             if (this is T25)
             {
                 _index = 25;
                 _value25 = (T25)(object)this;
                 return;
             }
+
             if (this is T26)
             {
                 _index = 26;
                 _value26 = (T26)(object)this;
                 return;
             }
+
             if (this is T27)
             {
                 _index = 27;
                 _value27 = (T27)(object)this;
                 return;
             }
+
             if (this is T28)
             {
                 _index = 28;
                 _value28 = (T28)(object)this;
                 return;
             }
+
             if (this is T29)
             {
                 _index = 29;
                 _value29 = (T29)(object)this;
                 return;
             }
+
             if (this is T30)
             {
                 _index = 30;
                 _value30 = (T30)(object)this;
                 return;
             }
+
             if (this is T31)
             {
                 _index = 31;
                 _value31 = (T31)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>.");
         }
 
         public object Value
@@ -24744,6 +24056,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -24759,9 +24073,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -24775,9 +24086,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -24793,9 +24101,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -24809,9 +24114,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -24827,9 +24129,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -24843,9 +24142,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -24861,9 +24157,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -24877,9 +24170,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(7, value7: t);
-
 
         public bool IsT8 => _index == 8;
 
@@ -24895,9 +24185,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(8, value8: t);
-
-
         public bool IsT9 => _index == 9;
 
         public T9 AsT9
@@ -24911,9 +24198,6 @@ namespace OneOf
                 return _value9;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T9 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(9, value9: t);
-
 
         public bool IsT10 => _index == 10;
 
@@ -24929,9 +24213,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T10 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(10, value10: t);
-
-
         public bool IsT11 => _index == 11;
 
         public T11 AsT11
@@ -24945,9 +24226,6 @@ namespace OneOf
                 return _value11;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T11 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(11, value11: t);
-
 
         public bool IsT12 => _index == 12;
 
@@ -24963,9 +24241,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T12 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(12, value12: t);
-
-
         public bool IsT13 => _index == 13;
 
         public T13 AsT13
@@ -24979,9 +24254,6 @@ namespace OneOf
                 return _value13;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T13 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(13, value13: t);
-
 
         public bool IsT14 => _index == 14;
 
@@ -24997,9 +24269,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T14 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(14, value14: t);
-
-
         public bool IsT15 => _index == 15;
 
         public T15 AsT15
@@ -25013,9 +24282,6 @@ namespace OneOf
                 return _value15;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T15 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(15, value15: t);
-
 
         public bool IsT16 => _index == 16;
 
@@ -25031,9 +24297,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T16 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(16, value16: t);
-
-
         public bool IsT17 => _index == 17;
 
         public T17 AsT17
@@ -25047,9 +24310,6 @@ namespace OneOf
                 return _value17;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T17 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(17, value17: t);
-
 
         public bool IsT18 => _index == 18;
 
@@ -25065,9 +24325,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T18 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(18, value18: t);
-
-
         public bool IsT19 => _index == 19;
 
         public T19 AsT19
@@ -25081,9 +24338,6 @@ namespace OneOf
                 return _value19;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T19 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(19, value19: t);
-
 
         public bool IsT20 => _index == 20;
 
@@ -25099,9 +24353,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T20 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(20, value20: t);
-
-
         public bool IsT21 => _index == 21;
 
         public T21 AsT21
@@ -25115,9 +24366,6 @@ namespace OneOf
                 return _value21;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T21 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(21, value21: t);
-
 
         public bool IsT22 => _index == 22;
 
@@ -25133,9 +24381,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T22 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(22, value22: t);
-
-
         public bool IsT23 => _index == 23;
 
         public T23 AsT23
@@ -25149,9 +24394,6 @@ namespace OneOf
                 return _value23;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T23 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(23, value23: t);
-
 
         public bool IsT24 => _index == 24;
 
@@ -25167,9 +24409,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T24 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(24, value24: t);
-
-
         public bool IsT25 => _index == 25;
 
         public T25 AsT25
@@ -25183,9 +24422,6 @@ namespace OneOf
                 return _value25;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T25 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(25, value25: t);
-
 
         public bool IsT26 => _index == 26;
 
@@ -25201,9 +24437,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T26 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(26, value26: t);
-
-
         public bool IsT27 => _index == 27;
 
         public T27 AsT27
@@ -25217,9 +24450,6 @@ namespace OneOf
                 return _value27;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T27 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(27, value27: t);
-
 
         public bool IsT28 => _index == 28;
 
@@ -25235,9 +24465,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T28 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(28, value28: t);
-
-
         public bool IsT29 => _index == 29;
 
         public T29 AsT29
@@ -25251,9 +24478,6 @@ namespace OneOf
                 return _value29;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T29 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(29, value29: t);
-
 
         public bool IsT30 => _index == 30;
 
@@ -25269,9 +24493,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T30 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(30, value30: t);
-
-
         public bool IsT31 => _index == 31;
 
         public T31 AsT31
@@ -25285,9 +24506,6 @@ namespace OneOf
                 return _value31;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(T31 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>(31, value31: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8, Action<T9> f9, Action<T10> f10, Action<T11> f11, Action<T12> f12, Action<T13> f13, Action<T14> f14, Action<T15> f15, Action<T16> f16, Action<T17> f17, Action<T18> f18, Action<T19> f19, Action<T20> f20, Action<T21> f21, Action<T22> f22, Action<T23> f23, Action<T24> f24, Action<T25> f25, Action<T26> f26, Action<T27> f27, Action<T28> f28, Action<T29> f29, Action<T30> f30, Action<T31> f31)
         {

--- a/OneOf.Tests/MixedReferenceAndValueTypeTests.cs
+++ b/OneOf.Tests/MixedReferenceAndValueTypeTests.cs
@@ -6,7 +6,7 @@ namespace OneOf.Tests
     public class RetryStrategy : OneOfBase<RetryStrategy.Never, int>
     {
         private RetryStrategy() { }
-        private RetryStrategy(int attempts):base(1, value1:attempts) { }
+        private RetryStrategy(int attempts):base(attempts) { }
 
         public static implicit operator RetryStrategy(int attempts)
         {

--- a/OneOf.Tests/NonhierarchyOneOfBase.cs
+++ b/OneOf.Tests/NonhierarchyOneOfBase.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace OneOf.Tests
+{
+    public class MetaValue : OneOfBase<string, bool, Random> 
+    {
+        public MetaValue(OneOf<string, bool, Random> input) : base(input) { }
+    }
+
+    public class MetaValue1 : OneOfBase<string, bool, Random>
+    {
+        public MetaValue1(string input) : base(input) { }
+        public MetaValue1(bool input) : base(input) { }
+        public MetaValue1(Random input) : base(input) { }
+    }
+
+    public class MetaValue2 : OneOfBase<string, MetaValue2.MetaValue2b, int>
+    {
+        protected MetaValue2() {}
+        public MetaValue2(string s) : base(s) {}
+
+        public class MetaValue2b : MetaValue2 {}
+
+        public MetaValue2(int i) : base() {  }
+    }
+
+    public class NonhierarchyOneOfBaseTests
+    {
+        [Test]
+        public void CanMatch() {
+            var metaValue = new MetaValue("abcd");
+            Assert.True(metaValue.IsT0);
+            Assert.False(metaValue.IsT1);
+            Assert.False(metaValue.IsT2);
+
+            metaValue = new MetaValue(true);
+            Assert.False(metaValue.IsT0);
+            Assert.True(metaValue.IsT1);
+            Assert.False(metaValue.IsT2);
+
+            metaValue = new MetaValue(new Random());
+            Assert.False(metaValue.IsT0);
+            Assert.False(metaValue.IsT1);
+            Assert.True(metaValue.IsT2);
+        }
+
+        [Test]
+        public void CanMatchSeparateConstructors()
+        {
+            var metaValue = new MetaValue1("abcd");
+            Assert.True(metaValue.IsT0);
+            Assert.False(metaValue.IsT1);
+            Assert.False(metaValue.IsT2);
+
+            metaValue = new MetaValue1(true);
+            Assert.False(metaValue.IsT0);
+            Assert.True(metaValue.IsT1);
+            Assert.False(metaValue.IsT2);
+
+            metaValue = new MetaValue1(new Random());
+            Assert.False(metaValue.IsT0);
+            Assert.False(metaValue.IsT1);
+            Assert.True(metaValue.IsT2);
+        }
+
+        [Test]
+        public void CanMatchMixedDerivedNonderived() {
+            MetaValue2 metaValue = new MetaValue2("abcd");
+            Assert.True(metaValue.IsT0);
+            Assert.False(metaValue.IsT1);
+
+            metaValue = new MetaValue2.MetaValue2b();
+            Assert.False(metaValue.IsT0);
+            Assert.True(metaValue.IsT1);
+        }
+
+        public void NoParameterlessConstructorForNonderived() {
+            Assert.Throws<InvalidOperationException>(() => new MetaValue2(5));
+        }
+    }
+}

--- a/OneOf.Tests/OneOf.Tests.csproj
+++ b/OneOf.Tests/OneOf.Tests.csproj
@@ -5,12 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OneOf\OneOf.csproj" />
   </ItemGroup>
-
 </Project>

--- a/OneOf/IOneOf.cs
+++ b/OneOf/IOneOf.cs
@@ -1,4 +1,8 @@
 namespace OneOf
 {
-    public interface IOneOf { object Value { get ; } }
+    public interface IOneOf 
+    { 
+        object Value { get ; }
+        int Index { get; }
+    }
 }

--- a/OneOf/OneOf.cs
+++ b/OneOf/OneOf.cs
@@ -26,6 +26,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -42,7 +44,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0>(T0 t) => new OneOf<T0>(0, value0: t);
-
 
         public void Switch(Action<T0> f0)
         {
@@ -157,6 +158,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -174,7 +177,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1>(T0 t) => new OneOf<T0, T1>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -190,7 +192,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1>(T1 t) => new OneOf<T0, T1>(1, value1: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
@@ -355,6 +356,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -372,7 +375,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2>(T0 t) => new OneOf<T0, T1, T2>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -389,7 +391,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2>(T1 t) => new OneOf<T0, T1, T2>(1, value1: t);
 
-
         public bool IsT2 => _index == 2;
 
         public T2 AsT2
@@ -405,7 +406,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2>(T2 t) => new OneOf<T0, T1, T2>(2, value2: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
@@ -621,6 +621,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -638,7 +640,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3>(T0 t) => new OneOf<T0, T1, T2, T3>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -654,7 +655,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3>(T1 t) => new OneOf<T0, T1, T2, T3>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -672,7 +672,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3>(T2 t) => new OneOf<T0, T1, T2, T3>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -688,7 +687,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3>(T3 t) => new OneOf<T0, T1, T2, T3>(3, value3: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
@@ -953,6 +951,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -970,7 +970,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T0 t) => new OneOf<T0, T1, T2, T3, T4>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -986,7 +985,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T1 t) => new OneOf<T0, T1, T2, T3, T4>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1004,7 +1002,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T2 t) => new OneOf<T0, T1, T2, T3, T4>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1021,7 +1018,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T3 t) => new OneOf<T0, T1, T2, T3, T4>(3, value3: t);
 
-
         public bool IsT4 => _index == 4;
 
         public T4 AsT4
@@ -1037,7 +1033,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4>(T4 t) => new OneOf<T0, T1, T2, T3, T4>(4, value4: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
@@ -1353,6 +1348,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1370,7 +1367,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1386,7 +1382,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1404,7 +1399,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1420,7 +1414,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1438,7 +1431,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1454,7 +1446,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5>(5, value5: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
@@ -1823,6 +1814,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1840,7 +1833,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1856,7 +1848,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1874,7 +1865,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1890,7 +1880,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1908,7 +1897,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1925,7 +1913,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(5, value5: t);
 
-
         public bool IsT6 => _index == 6;
 
         public T6 AsT6
@@ -1941,7 +1928,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6>(6, value6: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
@@ -2365,6 +2351,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2382,7 +2370,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2398,7 +2385,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2416,7 +2402,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2432,7 +2417,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2450,7 +2434,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2466,7 +2449,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2484,7 +2466,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2500,7 +2481,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7>(7, value7: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
@@ -2981,6 +2961,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2998,7 +2980,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(0, value0: t);
 
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -3014,7 +2995,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -3032,7 +3012,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(2, value2: t);
 
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -3048,7 +3027,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -3066,7 +3044,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(4, value4: t);
 
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -3082,7 +3059,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -3100,7 +3076,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(6, value6: t);
 
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -3117,7 +3092,6 @@ namespace OneOf
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(7, value7: t);
 
-
         public bool IsT8 => _index == 8;
 
         public T8 AsT8
@@ -3133,7 +3107,6 @@ namespace OneOf
         }
 
         public static implicit operator OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 t) => new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8>(8, value8: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {

--- a/OneOf/OneOfBase.cs
+++ b/OneOf/OneOfBase.cs
@@ -7,20 +7,27 @@ namespace OneOf
         readonly T0 _value0;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0))
+        protected OneOfBase(OneOf<T0> input)
         {
-            _index = index;
-            _value0 = value0;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0> parameterless constructor can only be invoked from a derived class of OneOfBase<T0>.");
         }
 
         public object Value
@@ -36,6 +43,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -50,9 +59,6 @@ namespace OneOf
                 return _value0;
             }
         }
-
-        public static implicit operator OneOfBase<T0>(T0 t) => new OneOfBase<T0>(0, value0: t);
-
 
         public void Switch(Action<T0> f0)
         {
@@ -133,27 +139,35 @@ namespace OneOf
         readonly T1 _value1;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1))
+        protected OneOfBase(OneOf<T0, T1> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1>.");
         }
 
         public object Value
@@ -171,6 +185,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -186,9 +202,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1>(T0 t) => new OneOfBase<T0, T1>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -202,9 +215,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1>(T1 t) => new OneOfBase<T0, T1>(1, value1: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1)
         {
@@ -314,34 +324,43 @@ namespace OneOf
         readonly T2 _value2;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2))
+        protected OneOfBase(OneOf<T0, T1, T2> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2>.");
         }
 
         public object Value
@@ -361,6 +380,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -376,9 +397,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2>(T0 t) => new OneOfBase<T0, T1, T2>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -393,9 +411,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2>(T1 t) => new OneOfBase<T0, T1, T2>(1, value1: t);
-
-
         public bool IsT2 => _index == 2;
 
         public T2 AsT2
@@ -409,9 +424,6 @@ namespace OneOf
                 return _value2;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2>(T2 t) => new OneOfBase<T0, T1, T2>(2, value2: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2)
         {
@@ -549,41 +561,51 @@ namespace OneOf
         readonly T3 _value3;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3))
+        protected OneOfBase(OneOf<T0, T1, T2, T3> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3>.");
         }
 
         public object Value
@@ -605,6 +627,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -620,9 +644,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T0 t) => new OneOfBase<T0, T1, T2, T3>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -636,9 +657,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T1 t) => new OneOfBase<T0, T1, T2, T3>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -654,9 +672,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T2 t) => new OneOfBase<T0, T1, T2, T3>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -670,9 +685,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3>(T3 t) => new OneOfBase<T0, T1, T2, T3>(3, value3: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3)
         {
@@ -834,48 +846,59 @@ namespace OneOf
         readonly T4 _value4;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4>.");
         }
 
         public object Value
@@ -899,6 +922,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -914,9 +939,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -930,9 +952,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -948,9 +967,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -965,9 +981,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4>(3, value3: t);
-
-
         public bool IsT4 => _index == 4;
 
         public T4 AsT4
@@ -981,9 +994,6 @@ namespace OneOf
                 return _value4;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4>(4, value4: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4)
         {
@@ -1169,55 +1179,67 @@ namespace OneOf
         readonly T5 _value5;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5>.");
         }
 
         public object Value
@@ -1243,6 +1265,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1258,9 +1282,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1274,9 +1295,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1292,9 +1310,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1308,9 +1323,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1326,9 +1338,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1342,9 +1351,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5>(5, value5: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5)
         {
@@ -1554,62 +1560,75 @@ namespace OneOf
         readonly T6 _value6;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6>.");
         }
 
         public object Value
@@ -1637,6 +1656,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -1652,9 +1673,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -1668,9 +1686,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -1686,9 +1701,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -1702,9 +1714,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -1720,9 +1729,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -1737,9 +1743,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(5, value5: t);
-
-
         public bool IsT6 => _index == 6;
 
         public T6 AsT6
@@ -1753,9 +1756,6 @@ namespace OneOf
                 return _value6;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6>(6, value6: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6)
         {
@@ -1989,69 +1989,83 @@ namespace OneOf
         readonly T7 _value7;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>.");
         }
 
         public object Value
@@ -2081,6 +2095,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2096,9 +2112,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2112,9 +2125,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2130,9 +2140,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2146,9 +2153,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2164,9 +2168,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2180,9 +2181,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2198,9 +2196,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2214,9 +2209,6 @@ namespace OneOf
                 return _value7;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7>(7, value7: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7)
         {
@@ -2474,76 +2466,91 @@ namespace OneOf
         readonly T8 _value8;
         readonly int _index;
 
-        protected OneOfBase(int index, T0 value0 = default(T0), T1 value1 = default(T1), T2 value2 = default(T2), T3 value3 = default(T3), T4 value4 = default(T4), T5 value5 = default(T5), T6 value6 = default(T6), T7 value7 = default(T7), T8 value8 = default(T8))
+        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> input)
         {
-            _index = index;
-            _value0 = value0;
-            _value1 = value1;
-            _value2 = value2;
-            _value3 = value3;
-            _value4 = value4;
-            _value5 = value5;
-            _value6 = value6;
-            _value7 = value7;
-            _value8 = value8;
+            _index = input.Index;
+            switch (_index)
+            {
+                case 0: _value0 = input.AsT0; break;
+                case 1: _value1 = input.AsT1; break;
+                case 2: _value2 = input.AsT2; break;
+                case 3: _value3 = input.AsT3; break;
+                case 4: _value4 = input.AsT4; break;
+                case 5: _value5 = input.AsT5; break;
+                case 6: _value6 = input.AsT6; break;
+                case 7: _value7 = input.AsT7; break;
+                case 8: _value8 = input.AsT8; break;
+                default: throw new InvalidOperationException();
+            }
         }
-
+        
         protected OneOfBase()
         {
+
             if (this is T0)
             {
                 _index = 0;
                 _value0 = (T0)(object)this;
                 return;
             }
+
             if (this is T1)
             {
                 _index = 1;
                 _value1 = (T1)(object)this;
                 return;
             }
+
             if (this is T2)
             {
                 _index = 2;
                 _value2 = (T2)(object)this;
                 return;
             }
+
             if (this is T3)
             {
                 _index = 3;
                 _value3 = (T3)(object)this;
                 return;
             }
+
             if (this is T4)
             {
                 _index = 4;
                 _value4 = (T4)(object)this;
                 return;
             }
+
             if (this is T5)
             {
                 _index = 5;
                 _value5 = (T5)(object)this;
                 return;
             }
+
             if (this is T6)
             {
                 _index = 6;
                 _value6 = (T6)(object)this;
                 return;
             }
+
             if (this is T7)
             {
                 _index = 7;
                 _value7 = (T7)(object)this;
                 return;
             }
+
             if (this is T8)
             {
                 _index = 8;
                 _value8 = (T8)(object)this;
                 return;
             }
+
+            throw new InvalidOperationException("OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> parameterless constructor can only be invoked from a derived class of OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>.");
         }
 
         public object Value
@@ -2575,6 +2582,8 @@ namespace OneOf
                 }
             }
         }
+        
+        public int Index => _index;
 
         public bool IsT0 => _index == 0;
 
@@ -2590,9 +2599,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T0 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(0, value0: t);
-
-
         public bool IsT1 => _index == 1;
 
         public T1 AsT1
@@ -2606,9 +2612,6 @@ namespace OneOf
                 return _value1;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T1 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(1, value1: t);
-
 
         public bool IsT2 => _index == 2;
 
@@ -2624,9 +2627,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T2 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(2, value2: t);
-
-
         public bool IsT3 => _index == 3;
 
         public T3 AsT3
@@ -2640,9 +2640,6 @@ namespace OneOf
                 return _value3;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T3 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(3, value3: t);
-
 
         public bool IsT4 => _index == 4;
 
@@ -2658,9 +2655,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T4 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(4, value4: t);
-
-
         public bool IsT5 => _index == 5;
 
         public T5 AsT5
@@ -2674,9 +2668,6 @@ namespace OneOf
                 return _value5;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T5 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(5, value5: t);
-
 
         public bool IsT6 => _index == 6;
 
@@ -2692,9 +2683,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T6 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(6, value6: t);
-
-
         public bool IsT7 => _index == 7;
 
         public T7 AsT7
@@ -2709,9 +2697,6 @@ namespace OneOf
             }
         }
 
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T7 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(7, value7: t);
-
-
         public bool IsT8 => _index == 8;
 
         public T8 AsT8
@@ -2725,9 +2710,6 @@ namespace OneOf
                 return _value8;
             }
         }
-
-        public static implicit operator OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(T8 t) => new OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8>(8, value8: t);
-
 
         public void Switch(Action<T0> f0, Action<T1> f1, Action<T2> f2, Action<T3> f3, Action<T4> f4, Action<T5> f5, Action<T6> f6, Action<T7> f7, Action<T8> f8)
         {


### PR DESCRIPTION
I carried out the changes outlined [here](https://github.com/mcintyre321/OneOf/issues/66#issuecomment-735695778):

1. Added an `int Index` property to `IOneOf`, and implementation for `OneOf` and `OneOfBase`
2. Replaced the index-based constructor on `OneOfBase`, with one that accepts a `OneOf` with the matching types
3. Added an exception to the `OneOfBase` parameterless constructor, when the `this`-type cannot be resolved to any of the subtypes. We can't rely on the new `OneOf`-accepting constructor, because it's impossible to pass `this` into a base constructor.
4. Removed all the implicit casts from `OneOfBase`.
5. Added tests for OneOfBase-class with no derived subtypes, with all derived subtypes, and with some derived subtypes. NB. In order to run the tests, I had to install the NUnit3TestAdapter and Microsoft.NET.Test.Sdk packages; otherwise Visual Studio simply wouldn't run the tests.
6. Updated the README. I also cleaned up quite a bit of whitespace.

I would note that some of the tests in `ToStringTests` (`LeftSideFormatsWithCurrentCulture` and `RightSideFormatsWithCurrentCulture`) failed for `en-NZ` culture, because the expected string had `AM` in upper-case, while my machine produced `am` in lower-case.

Also, when I targeted .NET 5 (not committed), the `CallingToStringOnANestedNonRecursiveTypeWorks` test also failed, apparently because the implementation of `string.ToString` has changed.