### PR TITLE
Compatibility w/ C# versions below 8

### DIFF
--- a/OneOf.Extended/OneOfBaseT10.generated.cs
+++ b/OneOf.Extended/OneOfBaseT10.generated.cs
@@ -38,22 +38,23 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -229,254 +230,256 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -492,41 +495,43 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT11.generated.cs
+++ b/OneOf.Extended/OneOfBaseT11.generated.cs
@@ -40,23 +40,24 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -246,288 +247,290 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -543,43 +546,45 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT12.generated.cs
+++ b/OneOf.Extended/OneOfBaseT12.generated.cs
@@ -42,24 +42,25 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -263,324 +264,326 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -596,45 +599,47 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT13.generated.cs
+++ b/OneOf.Extended/OneOfBaseT13.generated.cs
@@ -44,25 +44,26 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -280,362 +281,364 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -651,47 +654,49 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT14.generated.cs
+++ b/OneOf.Extended/OneOfBaseT14.generated.cs
@@ -46,26 +46,27 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -297,402 +298,404 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -708,49 +711,51 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT15.generated.cs
+++ b/OneOf.Extended/OneOfBaseT15.generated.cs
@@ -48,27 +48,28 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -314,444 +315,446 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -767,51 +770,53 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT16.generated.cs
+++ b/OneOf.Extended/OneOfBaseT16.generated.cs
@@ -50,28 +50,29 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -331,488 +332,490 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -828,53 +831,55 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT17.generated.cs
+++ b/OneOf.Extended/OneOfBaseT17.generated.cs
@@ -52,29 +52,30 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -348,534 +349,536 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -891,55 +894,57 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT18.generated.cs
+++ b/OneOf.Extended/OneOfBaseT18.generated.cs
@@ -54,30 +54,31 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -365,582 +366,584 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -956,57 +959,59 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT19.generated.cs
+++ b/OneOf.Extended/OneOfBaseT19.generated.cs
@@ -56,31 +56,32 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -382,632 +383,634 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1023,59 +1026,61 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT20.generated.cs
+++ b/OneOf.Extended/OneOfBaseT20.generated.cs
@@ -58,32 +58,33 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -399,684 +400,686 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1092,61 +1095,63 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT21.generated.cs
+++ b/OneOf.Extended/OneOfBaseT21.generated.cs
@@ -60,33 +60,34 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -416,738 +417,740 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1163,63 +1166,65 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT22.generated.cs
+++ b/OneOf.Extended/OneOfBaseT22.generated.cs
@@ -62,34 +62,35 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -433,794 +434,796 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1236,65 +1239,67 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT23.generated.cs
+++ b/OneOf.Extended/OneOfBaseT23.generated.cs
@@ -64,35 +64,36 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -450,852 +451,854 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1311,67 +1314,69 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT24.generated.cs
+++ b/OneOf.Extended/OneOfBaseT24.generated.cs
@@ -66,36 +66,37 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -467,912 +468,914 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1388,69 +1391,71 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT25.generated.cs
+++ b/OneOf.Extended/OneOfBaseT25.generated.cs
@@ -68,37 +68,38 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -484,974 +485,976 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1467,71 +1470,73 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT26.generated.cs
+++ b/OneOf.Extended/OneOfBaseT26.generated.cs
@@ -70,38 +70,39 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -501,1038 +502,1040 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1548,73 +1551,75 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT27.generated.cs
+++ b/OneOf.Extended/OneOfBaseT27.generated.cs
@@ -72,39 +72,40 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -518,1104 +519,1106 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1631,75 +1634,77 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT28.generated.cs
+++ b/OneOf.Extended/OneOfBaseT28.generated.cs
@@ -74,40 +74,41 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -535,1172 +536,1174 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1716,77 +1719,79 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT29.generated.cs
+++ b/OneOf.Extended/OneOfBaseT29.generated.cs
@@ -76,41 +76,42 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -552,1242 +553,1244 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1803,79 +1806,81 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT30.generated.cs
+++ b/OneOf.Extended/OneOfBaseT30.generated.cs
@@ -78,42 +78,43 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                30 => _value30,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                case 30: return _value30;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -569,1314 +570,1316 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT30 ? AsT30 : default;
-            remainder = _index switch
+        public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT30 ? AsT30 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT30;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT30;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                30 => Equals(_value30, other._value30),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                             case 30: return check1 && Equals(_value30, other._value30);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1892,81 +1895,83 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                30 => FormatValue(_value30),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                case 30: return FormatValue(_value30);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    30 => _value30?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    case 30: { hashCode = _value30?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT31.generated.cs
+++ b/OneOf.Extended/OneOfBaseT31.generated.cs
@@ -80,43 +80,44 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                30 => _value30,
-                31 => _value31,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                case 30: return _value30;
+                case 31: return _value31;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -586,1388 +587,1390 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
-		{
-			value = IsT30 ? AsT30 : default;
-            remainder = _index switch
+        public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
+        {
+            value = IsT30 ? AsT30 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => default,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT30;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = default; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT30;
+        }
         
-		public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT31 ? AsT31 : default;
-            remainder = _index switch
+        public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT31 ? AsT31 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT31;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT31;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                30 => Equals(_value30, other._value30),
-                31 => Equals(_value31, other._value31),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                             case 30: return check1 && Equals(_value30, other._value30);
+                             case 31: return check1 && Equals(_value31, other._value31);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1983,83 +1986,85 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                30 => FormatValue(_value30),
-                31 => FormatValue(_value31),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                case 30: return FormatValue(_value30);
+                case 31: return FormatValue(_value31);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    30 => _value30?.GetHashCode(),
-                    31 => _value31?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    case 30: { hashCode = _value30?.GetHashCode() ?? 0; break; }
+                    case 31: { hashCode = _value31?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfBaseT9.generated.cs
+++ b/OneOf.Extended/OneOfBaseT9.generated.cs
@@ -36,21 +36,22 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -212,222 +213,224 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -443,39 +446,41 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT10.generated.cs
+++ b/OneOf.Extended/OneOfT10.generated.cs
@@ -34,22 +34,23 @@ namespace OneOf
             _value10 = value10;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -250,21 +251,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -273,21 +274,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -296,21 +297,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -319,21 +320,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -342,21 +343,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -365,21 +366,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -388,21 +389,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -411,21 +412,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -434,21 +435,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -457,21 +458,21 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -480,271 +481,273 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -756,41 +759,43 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT11.generated.cs
+++ b/OneOf.Extended/OneOfT11.generated.cs
@@ -36,23 +36,24 @@ namespace OneOf
             _value11 = value11;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -269,22 +270,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -293,22 +294,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -317,22 +318,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -341,22 +342,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -365,22 +366,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -389,22 +390,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -413,22 +414,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -437,22 +438,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -461,22 +462,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -485,22 +486,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -509,22 +510,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -533,306 +534,308 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -844,43 +847,45 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT12.generated.cs
+++ b/OneOf.Extended/OneOfT12.generated.cs
@@ -38,24 +38,25 @@ namespace OneOf
             _value12 = value12;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -288,23 +289,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -313,23 +314,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -338,23 +339,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -363,23 +364,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -388,23 +389,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -413,23 +414,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -438,23 +439,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -463,23 +464,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -488,23 +489,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -513,23 +514,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -538,23 +539,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -563,23 +564,23 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -588,343 +589,345 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -936,45 +939,47 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT13.generated.cs
+++ b/OneOf.Extended/OneOfT13.generated.cs
@@ -40,25 +40,26 @@ namespace OneOf
             _value13 = value13;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -307,24 +308,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -333,24 +334,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -359,24 +360,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -385,24 +386,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -411,24 +412,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -437,24 +438,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -463,24 +464,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -489,24 +490,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -515,24 +516,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -541,24 +542,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -567,24 +568,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -593,24 +594,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -619,24 +620,24 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -645,382 +646,384 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1032,47 +1035,49 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT14.generated.cs
+++ b/OneOf.Extended/OneOfT14.generated.cs
@@ -42,26 +42,27 @@ namespace OneOf
             _value14 = value14;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -326,25 +327,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -353,25 +354,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -380,25 +381,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -407,25 +408,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -434,25 +435,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -461,25 +462,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -488,25 +489,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -515,25 +516,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -542,25 +543,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -569,25 +570,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -596,25 +597,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -623,25 +624,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -650,25 +651,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -677,25 +678,25 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -704,423 +705,425 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1132,49 +1135,51 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT15.generated.cs
+++ b/OneOf.Extended/OneOfT15.generated.cs
@@ -44,27 +44,28 @@ namespace OneOf
             _value15 = value15;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -345,26 +346,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -373,26 +374,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -401,26 +402,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -429,26 +430,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -457,26 +458,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -485,26 +486,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -513,26 +514,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -541,26 +542,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -569,26 +570,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -597,26 +598,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -625,26 +626,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -653,26 +654,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -681,26 +682,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -709,26 +710,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -737,26 +738,26 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -765,466 +766,468 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1236,51 +1239,53 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT16.generated.cs
+++ b/OneOf.Extended/OneOfT16.generated.cs
@@ -46,28 +46,29 @@ namespace OneOf
             _value16 = value16;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -364,27 +365,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -393,27 +394,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -422,27 +423,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -451,27 +452,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -480,27 +481,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -509,27 +510,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -538,27 +539,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -567,27 +568,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -596,27 +597,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -625,27 +626,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -654,27 +655,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -683,27 +684,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -712,27 +713,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -741,27 +742,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -770,27 +771,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -799,27 +800,27 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -828,511 +829,513 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1344,53 +1347,55 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT17.generated.cs
+++ b/OneOf.Extended/OneOfT17.generated.cs
@@ -48,29 +48,30 @@ namespace OneOf
             _value17 = value17;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -383,28 +384,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -413,28 +414,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -443,28 +444,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -473,28 +474,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -503,28 +504,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -533,28 +534,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -563,28 +564,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -593,28 +594,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -623,28 +624,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -653,28 +654,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -683,28 +684,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -713,28 +714,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -743,28 +744,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -773,28 +774,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -803,28 +804,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -833,28 +834,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -863,28 +864,28 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -893,558 +894,560 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1456,55 +1459,57 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT18.generated.cs
+++ b/OneOf.Extended/OneOfT18.generated.cs
@@ -50,30 +50,31 @@ namespace OneOf
             _value18 = value18;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -402,29 +403,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -433,29 +434,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -464,29 +465,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -495,29 +496,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -526,29 +527,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -557,29 +558,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -588,29 +589,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -619,29 +620,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -650,29 +651,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -681,29 +682,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -712,29 +713,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -743,29 +744,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -774,29 +775,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -805,29 +806,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -836,29 +837,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -867,29 +868,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -898,29 +899,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -929,29 +930,29 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -960,607 +961,609 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1572,57 +1575,59 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT19.generated.cs
+++ b/OneOf.Extended/OneOfT19.generated.cs
@@ -52,31 +52,32 @@ namespace OneOf
             _value19 = value19;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -421,30 +422,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -453,30 +454,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -485,30 +486,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -517,30 +518,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -549,30 +550,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -581,30 +582,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -613,30 +614,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -645,30 +646,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -677,30 +678,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -709,30 +710,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -741,30 +742,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -773,30 +774,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -805,30 +806,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -837,30 +838,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -869,30 +870,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -901,30 +902,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -933,30 +934,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -965,30 +966,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -997,30 +998,30 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1029,658 +1030,660 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1692,59 +1695,61 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT20.generated.cs
+++ b/OneOf.Extended/OneOfT20.generated.cs
@@ -54,32 +54,33 @@ namespace OneOf
             _value20 = value20;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -440,31 +441,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -473,31 +474,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -506,31 +507,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -539,31 +540,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -572,31 +573,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -605,31 +606,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -638,31 +639,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -671,31 +672,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -704,31 +705,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -737,31 +738,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -770,31 +771,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -803,31 +804,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -836,31 +837,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -869,31 +870,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -902,31 +903,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -935,31 +936,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -968,31 +969,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1001,31 +1002,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1034,31 +1035,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1067,31 +1068,31 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1100,711 +1101,713 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1816,61 +1819,63 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT21.generated.cs
+++ b/OneOf.Extended/OneOfT21.generated.cs
@@ -56,33 +56,34 @@ namespace OneOf
             _value21 = value21;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -459,32 +460,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -493,32 +494,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -527,32 +528,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -561,32 +562,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -595,32 +596,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -629,32 +630,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -663,32 +664,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -697,32 +698,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -731,32 +732,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -765,32 +766,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -799,32 +800,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -833,32 +834,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -867,32 +868,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -901,32 +902,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -935,32 +936,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -969,32 +970,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1003,32 +1004,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1037,32 +1038,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1071,32 +1072,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1105,32 +1106,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1139,32 +1140,32 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1173,766 +1174,768 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -1944,63 +1947,65 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT22.generated.cs
+++ b/OneOf.Extended/OneOfT22.generated.cs
@@ -58,34 +58,35 @@ namespace OneOf
             _value22 = value22;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -478,33 +479,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -513,33 +514,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -548,33 +549,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -583,33 +584,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -618,33 +619,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -653,33 +654,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -688,33 +689,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -723,33 +724,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -758,33 +759,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -793,33 +794,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -828,33 +829,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -863,33 +864,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -898,33 +899,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -933,33 +934,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -968,33 +969,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1003,33 +1004,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1038,33 +1039,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1073,33 +1074,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1108,33 +1109,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1143,33 +1144,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1178,33 +1179,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1213,33 +1214,33 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1248,823 +1249,825 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2076,65 +2079,67 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT23.generated.cs
+++ b/OneOf.Extended/OneOfT23.generated.cs
@@ -60,35 +60,36 @@ namespace OneOf
             _value23 = value23;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -497,34 +498,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -533,34 +534,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -569,34 +570,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -605,34 +606,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -641,34 +642,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -677,34 +678,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -713,34 +714,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -749,34 +750,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -785,34 +786,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -821,34 +822,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -857,34 +858,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -893,34 +894,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -929,34 +930,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -965,34 +966,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1001,34 +1002,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1037,34 +1038,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1073,34 +1074,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1109,34 +1110,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1145,34 +1146,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1181,34 +1182,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1217,34 +1218,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1253,34 +1254,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1289,34 +1290,34 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1325,882 +1326,884 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2212,67 +2215,69 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT24.generated.cs
+++ b/OneOf.Extended/OneOfT24.generated.cs
@@ -62,36 +62,37 @@ namespace OneOf
             _value24 = value24;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -516,35 +517,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -553,35 +554,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -590,35 +591,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -627,35 +628,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -664,35 +665,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -701,35 +702,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -738,35 +739,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -775,35 +776,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -812,35 +813,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -849,35 +850,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -886,35 +887,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -923,35 +924,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -960,35 +961,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -997,35 +998,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1034,35 +1035,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1071,35 +1072,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1108,35 +1109,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1145,35 +1146,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1182,35 +1183,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1219,35 +1220,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1256,35 +1257,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1293,35 +1294,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1330,35 +1331,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1367,35 +1368,35 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1404,943 +1405,945 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2352,69 +2355,71 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT25.generated.cs
+++ b/OneOf.Extended/OneOfT25.generated.cs
@@ -64,37 +64,38 @@ namespace OneOf
             _value25 = value25;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -535,36 +536,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -573,36 +574,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -611,36 +612,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -649,36 +650,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -687,36 +688,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -725,36 +726,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -763,36 +764,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -801,36 +802,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -839,36 +840,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -877,36 +878,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -915,36 +916,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -953,36 +954,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -991,36 +992,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1029,36 +1030,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1067,36 +1068,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1105,36 +1106,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1143,36 +1144,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1181,36 +1182,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1219,36 +1220,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1257,36 +1258,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1295,36 +1296,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1333,36 +1334,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1371,36 +1372,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1409,36 +1410,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1447,36 +1448,36 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1485,1006 +1486,1008 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2496,71 +2499,73 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT26.generated.cs
+++ b/OneOf.Extended/OneOfT26.generated.cs
@@ -66,38 +66,39 @@ namespace OneOf
             _value26 = value26;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -554,37 +555,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -593,37 +594,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -632,37 +633,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -671,37 +672,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -710,37 +711,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -749,37 +750,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -788,37 +789,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -827,37 +828,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -866,37 +867,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -905,37 +906,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -944,37 +945,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -983,37 +984,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1022,37 +1023,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1061,37 +1062,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1100,37 +1101,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1139,37 +1140,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1178,37 +1179,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1217,37 +1218,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1256,37 +1257,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1295,37 +1296,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1334,37 +1335,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1373,37 +1374,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1412,37 +1413,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1451,37 +1452,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1490,37 +1491,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1529,37 +1530,37 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1568,1071 +1569,1073 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2644,73 +2647,75 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT27.generated.cs
+++ b/OneOf.Extended/OneOfT27.generated.cs
@@ -68,39 +68,40 @@ namespace OneOf
             _value27 = value27;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -573,38 +574,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -613,38 +614,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -653,38 +654,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -693,38 +694,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -733,38 +734,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -773,38 +774,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -813,38 +814,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -853,38 +854,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -893,38 +894,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -933,38 +934,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -973,38 +974,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -1013,38 +1014,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1053,38 +1054,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1093,38 +1094,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1133,38 +1134,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1173,38 +1174,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1213,38 +1214,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1253,38 +1254,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26, T27> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1293,38 +1294,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26, T27> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1333,38 +1334,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26, T27> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1373,38 +1374,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26, T27> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1413,38 +1414,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26, T27> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1453,38 +1454,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26, T27> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1493,38 +1494,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26, T27> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1533,38 +1534,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26, T27> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1573,38 +1574,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult, T27> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1613,38 +1614,38 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                case 27: return AsT27;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, TResult> MapT27<TResult>(Func<T27, TResult> mapFunc)
@@ -1653,1138 +1654,1140 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return mapFunc(AsT27);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2796,75 +2799,77 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT28.generated.cs
+++ b/OneOf.Extended/OneOfT28.generated.cs
@@ -70,40 +70,41 @@ namespace OneOf
             _value28 = value28;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -592,39 +593,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -633,39 +634,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -674,39 +675,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -715,39 +716,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -756,39 +757,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -797,39 +798,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -838,39 +839,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -879,39 +880,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -920,39 +921,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -961,39 +962,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -1002,39 +1003,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -1043,39 +1044,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1084,39 +1085,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1125,39 +1126,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1166,39 +1167,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1207,39 +1208,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1248,39 +1249,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1289,39 +1290,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1330,39 +1331,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26, T27, T28> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1371,39 +1372,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26, T27, T28> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1412,39 +1413,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26, T27, T28> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1453,39 +1454,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26, T27, T28> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1494,39 +1495,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26, T27, T28> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1535,39 +1536,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26, T27, T28> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1576,39 +1577,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26, T27, T28> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1617,39 +1618,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult, T27, T28> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1658,39 +1659,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                case 27: return AsT27;
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, TResult, T28> MapT27<TResult>(Func<T27, TResult> mapFunc)
@@ -1699,39 +1700,39 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return mapFunc(AsT27);
+                case 28: return AsT28;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, TResult> MapT28<TResult>(Func<T28, TResult> mapFunc)
@@ -1740,1207 +1741,1209 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return mapFunc(AsT28);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -2952,77 +2955,79 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT29.generated.cs
+++ b/OneOf.Extended/OneOfT29.generated.cs
@@ -72,41 +72,42 @@ namespace OneOf
             _value29 = value29;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -611,40 +612,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -653,40 +654,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -695,40 +696,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -737,40 +738,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -779,40 +780,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -821,40 +822,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -863,40 +864,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -905,40 +906,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -947,40 +948,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -989,40 +990,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -1031,40 +1032,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -1073,40 +1074,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1115,40 +1116,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1157,40 +1158,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1199,40 +1200,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1241,40 +1242,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1283,40 +1284,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1325,40 +1326,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1367,40 +1368,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1409,40 +1410,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26, T27, T28, T29> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1451,40 +1452,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26, T27, T28, T29> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1493,40 +1494,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26, T27, T28, T29> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1535,40 +1536,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26, T27, T28, T29> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1577,40 +1578,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26, T27, T28, T29> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1619,40 +1620,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26, T27, T28, T29> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1661,40 +1662,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult, T27, T28, T29> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1703,40 +1704,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, TResult, T28, T29> MapT27<TResult>(Func<T27, TResult> mapFunc)
@@ -1745,40 +1746,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return mapFunc(AsT27);
+                case 28: return AsT28;
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, TResult, T29> MapT28<TResult>(Func<T28, TResult> mapFunc)
@@ -1787,40 +1788,40 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return mapFunc(AsT28);
+                case 29: return AsT29;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, TResult> MapT29<TResult>(Func<T29, TResult> mapFunc)
@@ -1829,1278 +1830,1280 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return mapFunc(AsT29);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -3112,79 +3115,81 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT30.generated.cs
+++ b/OneOf.Extended/OneOfT30.generated.cs
@@ -74,42 +74,43 @@ namespace OneOf
             _value30 = value30;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                30 => _value30,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                case 30: return _value30;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -630,41 +631,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -673,41 +674,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -716,41 +717,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -759,41 +760,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -802,41 +803,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -845,41 +846,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -888,41 +889,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -931,41 +932,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -974,41 +975,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -1017,41 +1018,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -1060,41 +1061,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -1103,41 +1104,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1146,41 +1147,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1189,41 +1190,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1232,41 +1233,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1275,41 +1276,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1318,41 +1319,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1361,41 +1362,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1404,41 +1405,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1447,41 +1448,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1490,41 +1491,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26, T27, T28, T29, T30> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1533,41 +1534,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26, T27, T28, T29, T30> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1576,41 +1577,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26, T27, T28, T29, T30> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1619,41 +1620,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26, T27, T28, T29, T30> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1662,41 +1663,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26, T27, T28, T29, T30> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1705,41 +1706,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult, T27, T28, T29, T30> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1748,41 +1749,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, TResult, T28, T29, T30> MapT27<TResult>(Func<T27, TResult> mapFunc)
@@ -1791,41 +1792,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return mapFunc(AsT27);
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, TResult, T29, T30> MapT28<TResult>(Func<T28, TResult> mapFunc)
@@ -1834,41 +1835,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return mapFunc(AsT28);
+                case 29: return AsT29;
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, TResult, T30> MapT29<TResult>(Func<T29, TResult> mapFunc)
@@ -1877,41 +1878,41 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return mapFunc(AsT29);
+                case 30: return AsT30;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, TResult> MapT30<TResult>(Func<T30, TResult> mapFunc)
@@ -1920,1351 +1921,1353 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => mapFunc(AsT30),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return mapFunc(AsT30);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                30 => AsT30,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                case 30: { remainder = AsT30; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
-		{
-			value = IsT30 ? AsT30 : default;
-            remainder = _index switch
+        public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> remainder)
+        {
+            value = IsT30 ? AsT30 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT30;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT30;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                30 => Equals(_value30, other._value30),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                             case 30: return check1 && Equals(_value30, other._value30);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -3276,81 +3279,83 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                30 => FormatValue(_value30),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                case 30: return FormatValue(_value30);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    30 => _value30?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    case 30: { hashCode = _value30?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT31.generated.cs
+++ b/OneOf.Extended/OneOfT31.generated.cs
@@ -76,43 +76,44 @@ namespace OneOf
             _value31 = value31;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                10 => _value10,
-                11 => _value11,
-                12 => _value12,
-                13 => _value13,
-                14 => _value14,
-                15 => _value15,
-                16 => _value16,
-                17 => _value17,
-                18 => _value18,
-                19 => _value19,
-                20 => _value20,
-                21 => _value21,
-                22 => _value22,
-                23 => _value23,
-                24 => _value24,
-                25 => _value25,
-                26 => _value26,
-                27 => _value27,
-                28 => _value28,
-                29 => _value29,
-                30 => _value30,
-                31 => _value31,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                case 10: return _value10;
+                case 11: return _value11;
+                case 12: return _value12;
+                case 13: return _value13;
+                case 14: return _value14;
+                case 15: return _value15;
+                case 16: return _value16;
+                case 17: return _value17;
+                case 18: return _value18;
+                case 19: return _value19;
+                case 20: return _value20;
+                case 21: return _value21;
+                case 22: return _value22;
+                case 23: return _value23;
+                case 24: return _value24;
+                case 25: return _value25;
+                case 26: return _value26;
+                case 27: return _value27;
+                case 28: return _value28;
+                case 29: return _value29;
+                case 30: return _value30;
+                case 31: return _value31;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -649,42 +650,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -693,42 +694,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -737,42 +738,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -781,42 +782,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -825,42 +826,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -869,42 +870,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -913,42 +914,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -957,42 +958,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -1001,42 +1002,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -1045,42 +1046,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT10<TResult>(Func<T10, TResult> mapFunc)
@@ -1089,42 +1090,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => mapFunc(AsT10),
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return mapFunc(AsT10);
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT11<TResult>(Func<T11, TResult> mapFunc)
@@ -1133,42 +1134,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => mapFunc(AsT11),
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return mapFunc(AsT11);
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT12<TResult>(Func<T12, TResult> mapFunc)
@@ -1177,42 +1178,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => mapFunc(AsT12),
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return mapFunc(AsT12);
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT13<TResult>(Func<T13, TResult> mapFunc)
@@ -1221,42 +1222,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => mapFunc(AsT13),
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return mapFunc(AsT13);
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT14<TResult>(Func<T14, TResult> mapFunc)
@@ -1265,42 +1266,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => mapFunc(AsT14),
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return mapFunc(AsT14);
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT15<TResult>(Func<T15, TResult> mapFunc)
@@ -1309,42 +1310,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => mapFunc(AsT15),
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return mapFunc(AsT15);
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT16<TResult>(Func<T16, TResult> mapFunc)
@@ -1353,42 +1354,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => mapFunc(AsT16),
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return mapFunc(AsT16);
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT17<TResult>(Func<T17, TResult> mapFunc)
@@ -1397,42 +1398,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => mapFunc(AsT17),
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return mapFunc(AsT17);
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TResult, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT18<TResult>(Func<T18, TResult> mapFunc)
@@ -1441,42 +1442,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => mapFunc(AsT18),
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return mapFunc(AsT18);
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TResult, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT19<TResult>(Func<T19, TResult> mapFunc)
@@ -1485,42 +1486,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => mapFunc(AsT19),
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return mapFunc(AsT19);
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TResult, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT20<TResult>(Func<T20, TResult> mapFunc)
@@ -1529,42 +1530,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => mapFunc(AsT20),
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return mapFunc(AsT20);
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TResult, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT21<TResult>(Func<T21, TResult> mapFunc)
@@ -1573,42 +1574,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => mapFunc(AsT21),
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return mapFunc(AsT21);
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TResult, T23, T24, T25, T26, T27, T28, T29, T30, T31> MapT22<TResult>(Func<T22, TResult> mapFunc)
@@ -1617,42 +1618,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => mapFunc(AsT22),
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return mapFunc(AsT22);
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TResult, T24, T25, T26, T27, T28, T29, T30, T31> MapT23<TResult>(Func<T23, TResult> mapFunc)
@@ -1661,42 +1662,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => mapFunc(AsT23),
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return mapFunc(AsT23);
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TResult, T25, T26, T27, T28, T29, T30, T31> MapT24<TResult>(Func<T24, TResult> mapFunc)
@@ -1705,42 +1706,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => mapFunc(AsT24),
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return mapFunc(AsT24);
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TResult, T26, T27, T28, T29, T30, T31> MapT25<TResult>(Func<T25, TResult> mapFunc)
@@ -1749,42 +1750,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => mapFunc(AsT25),
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return mapFunc(AsT25);
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, TResult, T27, T28, T29, T30, T31> MapT26<TResult>(Func<T26, TResult> mapFunc)
@@ -1793,42 +1794,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => mapFunc(AsT26),
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return mapFunc(AsT26);
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, TResult, T28, T29, T30, T31> MapT27<TResult>(Func<T27, TResult> mapFunc)
@@ -1837,42 +1838,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => mapFunc(AsT27),
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return mapFunc(AsT27);
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, TResult, T29, T30, T31> MapT28<TResult>(Func<T28, TResult> mapFunc)
@@ -1881,42 +1882,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => mapFunc(AsT28),
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return mapFunc(AsT28);
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, TResult, T30, T31> MapT29<TResult>(Func<T29, TResult> mapFunc)
@@ -1925,42 +1926,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => mapFunc(AsT29),
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return mapFunc(AsT29);
+                case 30: return AsT30;
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, TResult, T31> MapT30<TResult>(Func<T30, TResult> mapFunc)
@@ -1969,42 +1970,42 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => mapFunc(AsT30),
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return mapFunc(AsT30);
+                case 31: return AsT31;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, TResult> MapT31<TResult>(Func<T31, TResult> mapFunc)
@@ -2013,1426 +2014,1428 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => mapFunc(AsT31),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                case 10: return AsT10;
+                case 11: return AsT11;
+                case 12: return AsT12;
+                case 13: return AsT13;
+                case 14: return AsT14;
+                case 15: return AsT15;
+                case 16: return AsT16;
+                case 17: return AsT17;
+                case 18: return AsT18;
+                case 19: return AsT19;
+                case 20: return AsT20;
+                case 21: return AsT21;
+                case 22: return AsT22;
+                case 23: return AsT23;
+                case 24: return AsT24;
+                case 25: return AsT25;
+                case 26: return AsT26;
+                case 27: return AsT27;
+                case 28: return AsT28;
+                case 29: return AsT29;
+                case 30: return AsT30;
+                case 31: return mapFunc(AsT31);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
         
-		public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT10 ? AsT10 : default;
-            remainder = _index switch
+        public bool TryPickT10(out T10 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT10 ? AsT10 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => default,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT10;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = default; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT10;
+        }
         
-		public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT11 ? AsT11 : default;
-            remainder = _index switch
+        public bool TryPickT11(out T11 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT11 ? AsT11 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => default,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT11;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = default; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT11;
+        }
         
-		public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT12 ? AsT12 : default;
-            remainder = _index switch
+        public bool TryPickT12(out T12 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT12 ? AsT12 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => default,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT12;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = default; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT12;
+        }
         
-		public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT13 ? AsT13 : default;
-            remainder = _index switch
+        public bool TryPickT13(out T13 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT13 ? AsT13 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => default,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT13;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = default; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT13;
+        }
         
-		public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT14 ? AsT14 : default;
-            remainder = _index switch
+        public bool TryPickT14(out T14 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT14 ? AsT14 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => default,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT14;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = default; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT14;
+        }
         
-		public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT15 ? AsT15 : default;
-            remainder = _index switch
+        public bool TryPickT15(out T15 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT15 ? AsT15 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => default,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT15;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = default; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT15;
+        }
         
-		public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT16 ? AsT16 : default;
-            remainder = _index switch
+        public bool TryPickT16(out T16 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT16 ? AsT16 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => default,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT16;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = default; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT16;
+        }
         
-		public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT17 ? AsT17 : default;
-            remainder = _index switch
+        public bool TryPickT17(out T17 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT17 ? AsT17 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => default,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT17;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = default; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT17;
+        }
         
-		public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT18 ? AsT18 : default;
-            remainder = _index switch
+        public bool TryPickT18(out T18 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT18 ? AsT18 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => default,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT18;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = default; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT18;
+        }
         
-		public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT19 ? AsT19 : default;
-            remainder = _index switch
+        public bool TryPickT19(out T19 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT19 ? AsT19 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => default,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT19;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = default; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT19;
+        }
         
-		public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT20 ? AsT20 : default;
-            remainder = _index switch
+        public bool TryPickT20(out T20 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT20 ? AsT20 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => default,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT20;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = default; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT20;
+        }
         
-		public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT21 ? AsT21 : default;
-            remainder = _index switch
+        public bool TryPickT21(out T21 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT21 ? AsT21 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => default,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT21;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = default; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT21;
+        }
         
-		public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT22 ? AsT22 : default;
-            remainder = _index switch
+        public bool TryPickT22(out T22 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T23, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT22 ? AsT22 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => default,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT22;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = default; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT22;
+        }
         
-		public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT23 ? AsT23 : default;
-            remainder = _index switch
+        public bool TryPickT23(out T23 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T24, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT23 ? AsT23 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => default,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT23;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = default; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT23;
+        }
         
-		public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT24 ? AsT24 : default;
-            remainder = _index switch
+        public bool TryPickT24(out T24 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T25, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT24 ? AsT24 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => default,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT24;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = default; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT24;
+        }
         
-		public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT25 ? AsT25 : default;
-            remainder = _index switch
+        public bool TryPickT25(out T25 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T26, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT25 ? AsT25 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => default,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT25;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = default; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT25;
+        }
         
-		public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
-		{
-			value = IsT26 ? AsT26 : default;
-            remainder = _index switch
+        public bool TryPickT26(out T26 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T27, T28, T29, T30, T31> remainder)
+        {
+            value = IsT26 ? AsT26 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => default,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT26;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = default; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT26;
+        }
         
-		public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
-		{
-			value = IsT27 ? AsT27 : default;
-            remainder = _index switch
+        public bool TryPickT27(out T27 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T28, T29, T30, T31> remainder)
+        {
+            value = IsT27 ? AsT27 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => default,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT27;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = default; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT27;
+        }
         
-		public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
-		{
-			value = IsT28 ? AsT28 : default;
-            remainder = _index switch
+        public bool TryPickT28(out T28 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T29, T30, T31> remainder)
+        {
+            value = IsT28 ? AsT28 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => default,
-                29 => AsT29,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT28;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = default; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT28;
+        }
         
-		public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
-		{
-			value = IsT29 ? AsT29 : default;
-            remainder = _index switch
+        public bool TryPickT29(out T29 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T30, T31> remainder)
+        {
+            value = IsT29 ? AsT29 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => default,
-                30 => AsT30,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT29;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = default; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT29;
+        }
         
-		public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
-		{
-			value = IsT30 ? AsT30 : default;
-            remainder = _index switch
+        public bool TryPickT30(out T30 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T31> remainder)
+        {
+            value = IsT30 ? AsT30 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => default,
-                31 => AsT31,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT30;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = default; break; }
+                case 31: { remainder = AsT31; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT30;
+        }
         
-		public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
-		{
-			value = IsT31 ? AsT31 : default;
-            remainder = _index switch
+        public bool TryPickT31(out T31 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> remainder)
+        {
+            value = IsT31 ? AsT31 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                10 => AsT10,
-                11 => AsT11,
-                12 => AsT12,
-                13 => AsT13,
-                14 => AsT14,
-                15 => AsT15,
-                16 => AsT16,
-                17 => AsT17,
-                18 => AsT18,
-                19 => AsT19,
-                20 => AsT20,
-                21 => AsT21,
-                22 => AsT22,
-                23 => AsT23,
-                24 => AsT24,
-                25 => AsT25,
-                26 => AsT26,
-                27 => AsT27,
-                28 => AsT28,
-                29 => AsT29,
-                30 => AsT30,
-                31 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT31;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                case 10: { remainder = AsT10; break; }
+                case 11: { remainder = AsT11; break; }
+                case 12: { remainder = AsT12; break; }
+                case 13: { remainder = AsT13; break; }
+                case 14: { remainder = AsT14; break; }
+                case 15: { remainder = AsT15; break; }
+                case 16: { remainder = AsT16; break; }
+                case 17: { remainder = AsT17; break; }
+                case 18: { remainder = AsT18; break; }
+                case 19: { remainder = AsT19; break; }
+                case 20: { remainder = AsT20; break; }
+                case 21: { remainder = AsT21; break; }
+                case 22: { remainder = AsT22; break; }
+                case 23: { remainder = AsT23; break; }
+                case 24: { remainder = AsT24; break; }
+                case 25: { remainder = AsT25; break; }
+                case 26: { remainder = AsT26; break; }
+                case 27: { remainder = AsT27; break; }
+                case 28: { remainder = AsT28; break; }
+                case 29: { remainder = AsT29; break; }
+                case 30: { remainder = AsT30; break; }
+                case 31: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT31;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                10 => Equals(_value10, other._value10),
-                11 => Equals(_value11, other._value11),
-                12 => Equals(_value12, other._value12),
-                13 => Equals(_value13, other._value13),
-                14 => Equals(_value14, other._value14),
-                15 => Equals(_value15, other._value15),
-                16 => Equals(_value16, other._value16),
-                17 => Equals(_value17, other._value17),
-                18 => Equals(_value18, other._value18),
-                19 => Equals(_value19, other._value19),
-                20 => Equals(_value20, other._value20),
-                21 => Equals(_value21, other._value21),
-                22 => Equals(_value22, other._value22),
-                23 => Equals(_value23, other._value23),
-                24 => Equals(_value24, other._value24),
-                25 => Equals(_value25, other._value25),
-                26 => Equals(_value26, other._value26),
-                27 => Equals(_value27, other._value27),
-                28 => Equals(_value28, other._value28),
-                29 => Equals(_value29, other._value29),
-                30 => Equals(_value30, other._value30),
-                31 => Equals(_value31, other._value31),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                             case 10: return check1 && Equals(_value10, other._value10);
+                             case 11: return check1 && Equals(_value11, other._value11);
+                             case 12: return check1 && Equals(_value12, other._value12);
+                             case 13: return check1 && Equals(_value13, other._value13);
+                             case 14: return check1 && Equals(_value14, other._value14);
+                             case 15: return check1 && Equals(_value15, other._value15);
+                             case 16: return check1 && Equals(_value16, other._value16);
+                             case 17: return check1 && Equals(_value17, other._value17);
+                             case 18: return check1 && Equals(_value18, other._value18);
+                             case 19: return check1 && Equals(_value19, other._value19);
+                             case 20: return check1 && Equals(_value20, other._value20);
+                             case 21: return check1 && Equals(_value21, other._value21);
+                             case 22: return check1 && Equals(_value22, other._value22);
+                             case 23: return check1 && Equals(_value23, other._value23);
+                             case 24: return check1 && Equals(_value24, other._value24);
+                             case 25: return check1 && Equals(_value25, other._value25);
+                             case 26: return check1 && Equals(_value26, other._value26);
+                             case 27: return check1 && Equals(_value27, other._value27);
+                             case 28: return check1 && Equals(_value28, other._value28);
+                             case 29: return check1 && Equals(_value29, other._value29);
+                             case 30: return check1 && Equals(_value30, other._value30);
+                             case 31: return check1 && Equals(_value31, other._value31);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -3444,83 +3447,85 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                10 => FormatValue(_value10),
-                11 => FormatValue(_value11),
-                12 => FormatValue(_value12),
-                13 => FormatValue(_value13),
-                14 => FormatValue(_value14),
-                15 => FormatValue(_value15),
-                16 => FormatValue(_value16),
-                17 => FormatValue(_value17),
-                18 => FormatValue(_value18),
-                19 => FormatValue(_value19),
-                20 => FormatValue(_value20),
-                21 => FormatValue(_value21),
-                22 => FormatValue(_value22),
-                23 => FormatValue(_value23),
-                24 => FormatValue(_value24),
-                25 => FormatValue(_value25),
-                26 => FormatValue(_value26),
-                27 => FormatValue(_value27),
-                28 => FormatValue(_value28),
-                29 => FormatValue(_value29),
-                30 => FormatValue(_value30),
-                31 => FormatValue(_value31),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                case 10: return FormatValue(_value10);
+                case 11: return FormatValue(_value11);
+                case 12: return FormatValue(_value12);
+                case 13: return FormatValue(_value13);
+                case 14: return FormatValue(_value14);
+                case 15: return FormatValue(_value15);
+                case 16: return FormatValue(_value16);
+                case 17: return FormatValue(_value17);
+                case 18: return FormatValue(_value18);
+                case 19: return FormatValue(_value19);
+                case 20: return FormatValue(_value20);
+                case 21: return FormatValue(_value21);
+                case 22: return FormatValue(_value22);
+                case 23: return FormatValue(_value23);
+                case 24: return FormatValue(_value24);
+                case 25: return FormatValue(_value25);
+                case 26: return FormatValue(_value26);
+                case 27: return FormatValue(_value27);
+                case 28: return FormatValue(_value28);
+                case 29: return FormatValue(_value29);
+                case 30: return FormatValue(_value30);
+                case 31: return FormatValue(_value31);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    10 => _value10?.GetHashCode(),
-                    11 => _value11?.GetHashCode(),
-                    12 => _value12?.GetHashCode(),
-                    13 => _value13?.GetHashCode(),
-                    14 => _value14?.GetHashCode(),
-                    15 => _value15?.GetHashCode(),
-                    16 => _value16?.GetHashCode(),
-                    17 => _value17?.GetHashCode(),
-                    18 => _value18?.GetHashCode(),
-                    19 => _value19?.GetHashCode(),
-                    20 => _value20?.GetHashCode(),
-                    21 => _value21?.GetHashCode(),
-                    22 => _value22?.GetHashCode(),
-                    23 => _value23?.GetHashCode(),
-                    24 => _value24?.GetHashCode(),
-                    25 => _value25?.GetHashCode(),
-                    26 => _value26?.GetHashCode(),
-                    27 => _value27?.GetHashCode(),
-                    28 => _value28?.GetHashCode(),
-                    29 => _value29?.GetHashCode(),
-                    30 => _value30?.GetHashCode(),
-                    31 => _value31?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    case 10: { hashCode = _value10?.GetHashCode() ?? 0; break; }
+                    case 11: { hashCode = _value11?.GetHashCode() ?? 0; break; }
+                    case 12: { hashCode = _value12?.GetHashCode() ?? 0; break; }
+                    case 13: { hashCode = _value13?.GetHashCode() ?? 0; break; }
+                    case 14: { hashCode = _value14?.GetHashCode() ?? 0; break; }
+                    case 15: { hashCode = _value15?.GetHashCode() ?? 0; break; }
+                    case 16: { hashCode = _value16?.GetHashCode() ?? 0; break; }
+                    case 17: { hashCode = _value17?.GetHashCode() ?? 0; break; }
+                    case 18: { hashCode = _value18?.GetHashCode() ?? 0; break; }
+                    case 19: { hashCode = _value19?.GetHashCode() ?? 0; break; }
+                    case 20: { hashCode = _value20?.GetHashCode() ?? 0; break; }
+                    case 21: { hashCode = _value21?.GetHashCode() ?? 0; break; }
+                    case 22: { hashCode = _value22?.GetHashCode() ?? 0; break; }
+                    case 23: { hashCode = _value23?.GetHashCode() ?? 0; break; }
+                    case 24: { hashCode = _value24?.GetHashCode() ?? 0; break; }
+                    case 25: { hashCode = _value25?.GetHashCode() ?? 0; break; }
+                    case 26: { hashCode = _value26?.GetHashCode() ?? 0; break; }
+                    case 27: { hashCode = _value27?.GetHashCode() ?? 0; break; }
+                    case 28: { hashCode = _value28?.GetHashCode() ?? 0; break; }
+                    case 29: { hashCode = _value29?.GetHashCode() ?? 0; break; }
+                    case 30: { hashCode = _value30?.GetHashCode() ?? 0; break; }
+                    case 31: { hashCode = _value31?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf.Extended/OneOfT9.generated.cs
+++ b/OneOf.Extended/OneOfT9.generated.cs
@@ -32,21 +32,22 @@ namespace OneOf
             _value9 = value9;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                9 => _value9,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                case 9: return _value9;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -231,20 +232,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8, T9> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -253,20 +254,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8, T9> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -275,20 +276,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8, T9> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -297,20 +298,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8, T9> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -319,20 +320,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8, T9> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -341,20 +342,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8, T9> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -363,20 +364,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8, T9> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -385,20 +386,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult, T9> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -407,20 +408,20 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                case 9: return AsT9;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, TResult> MapT9<TResult>(Func<T9, TResult> mapFunc)
@@ -429,238 +430,240 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => mapFunc(AsT9),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                case 9: return mapFunc(AsT9);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8, T9> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8, T9> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8, T9> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8, T9> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T9> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                9 => AsT9,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                case 9: { remainder = AsT9; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
         
-		public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT9 ? AsT9 : default;
-            remainder = _index switch
+        public bool TryPickT9(out T9 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT9 ? AsT9 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                9 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT9;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                case 9: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT9;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                9 => Equals(_value9, other._value9),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                             case 9: return check1 && Equals(_value9, other._value9);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -672,39 +675,41 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                9 => FormatValue(_value9),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                case 9: return FormatValue(_value9);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    9 => _value9?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    case 9: { hashCode = _value9?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT0.generated.cs
+++ b/OneOf/OneOfBaseT0.generated.cs
@@ -18,12 +18,13 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -59,13 +60,15 @@ namespace OneOf
 
         
 
-        bool Equals(OneOfBase<T0> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -81,21 +84,23 @@ namespace OneOf
             return obj is OneOfBase<T0> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT1.generated.cs
+++ b/OneOf/OneOfBaseT1.generated.cs
@@ -20,13 +20,14 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -76,38 +77,40 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out T1 remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out T1 remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out T0 remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out T0 remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
 
-        bool Equals(OneOfBase<T0, T1> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -123,23 +126,25 @@ namespace OneOf
             return obj is OneOfBase<T0, T1> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT2.generated.cs
+++ b/OneOf/OneOfBaseT2.generated.cs
@@ -22,14 +22,15 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -93,54 +94,56 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -156,25 +159,27 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT3.generated.cs
+++ b/OneOf/OneOfBaseT3.generated.cs
@@ -24,15 +24,16 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -110,72 +111,74 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -191,27 +194,29 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT4.generated.cs
+++ b/OneOf/OneOfBaseT4.generated.cs
@@ -26,16 +26,17 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -127,92 +128,94 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -228,29 +231,31 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT5.generated.cs
+++ b/OneOf/OneOfBaseT5.generated.cs
@@ -28,17 +28,18 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -144,114 +145,116 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -267,31 +270,33 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT6.generated.cs
+++ b/OneOf/OneOfBaseT6.generated.cs
@@ -30,18 +30,19 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -161,138 +162,140 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -308,33 +311,35 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT7.generated.cs
+++ b/OneOf/OneOfBaseT7.generated.cs
@@ -32,19 +32,20 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -178,164 +179,166 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -351,35 +354,37 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfBaseT8.generated.cs
+++ b/OneOf/OneOfBaseT8.generated.cs
@@ -34,20 +34,21 @@ namespace OneOf
             }
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -195,192 +196,194 @@ namespace OneOf
 
         
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
 
-        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -396,37 +399,39 @@ namespace OneOf
             return obj is OneOfBase<T0, T1, T2, T3, T4, T5, T6, T7, T8> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT0.generated.cs
+++ b/OneOf/OneOfT0.generated.cs
@@ -14,12 +14,13 @@ namespace OneOf
             _value0 = value0;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -60,20 +61,22 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-        bool Equals(OneOf<T0> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -85,21 +88,23 @@ namespace OneOf
             return obj is OneOf<T0> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT1.generated.cs
+++ b/OneOf/OneOfT1.generated.cs
@@ -16,13 +16,14 @@ namespace OneOf
             _value1 = value1;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -79,12 +80,12 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -93,46 +94,48 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out T1 remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out T1 remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out T0 remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out T0 remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
 
-        bool Equals(OneOf<T0, T1> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -144,23 +147,25 @@ namespace OneOf
             return obj is OneOf<T0, T1> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT2.generated.cs
+++ b/OneOf/OneOfT2.generated.cs
@@ -18,14 +18,15 @@ namespace OneOf
             _value2 = value2;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -98,13 +99,13 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -113,13 +114,13 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -128,63 +129,65 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
 
-        bool Equals(OneOf<T0, T1, T2> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -196,25 +199,27 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT3.generated.cs
+++ b/OneOf/OneOfT3.generated.cs
@@ -20,15 +20,16 @@ namespace OneOf
             _value3 = value3;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -117,14 +118,14 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -133,14 +134,14 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -149,14 +150,14 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -165,82 +166,84 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -252,27 +255,29 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT4.generated.cs
+++ b/OneOf/OneOfT4.generated.cs
@@ -22,16 +22,17 @@ namespace OneOf
             _value4 = value4;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -136,15 +137,15 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -153,15 +154,15 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -170,15 +171,15 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -187,15 +188,15 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -204,103 +205,105 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -312,29 +315,31 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT5.generated.cs
+++ b/OneOf/OneOfT5.generated.cs
@@ -24,17 +24,18 @@ namespace OneOf
             _value5 = value5;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -155,16 +156,16 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -173,16 +174,16 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -191,16 +192,16 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -209,16 +210,16 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -227,16 +228,16 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -245,126 +246,128 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -376,31 +379,33 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT6.generated.cs
+++ b/OneOf/OneOfT6.generated.cs
@@ -26,18 +26,19 @@ namespace OneOf
             _value6 = value6;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -174,17 +175,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -193,17 +194,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -212,17 +213,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -231,17 +232,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -250,17 +251,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -269,17 +270,17 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -288,151 +289,153 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -444,33 +447,35 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT7.generated.cs
+++ b/OneOf/OneOfT7.generated.cs
@@ -28,19 +28,20 @@ namespace OneOf
             _value7 = value7;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -193,18 +194,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -213,18 +214,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -233,18 +234,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -253,18 +254,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -273,18 +274,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -293,18 +294,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -313,18 +314,18 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -333,178 +334,180 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -516,35 +519,37 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }

--- a/OneOf/OneOfT8.generated.cs
+++ b/OneOf/OneOfT8.generated.cs
@@ -30,20 +30,21 @@ namespace OneOf
             _value8 = value8;
         }
 
-        public object Value =>
-            _index switch
-            {
-                0 => _value0,
-                1 => _value1,
-                2 => _value2,
-                3 => _value3,
-                4 => _value4,
-                5 => _value5,
-                6 => _value6,
-                7 => _value7,
-                8 => _value8,
-                _ => throw new InvalidOperationException()
-            };
+    public object Value { get {
+                    switch (_index)
+                    {
+                            case 0: return _value0;
+                case 1: return _value1;
+                case 2: return _value2;
+                case 3: return _value3;
+                case 4: return _value4;
+                case 5: return _value5;
+                case 6: return _value6;
+                case 7: return _value7;
+                case 8: return _value8;
+                            default: throw new InvalidOperationException();
+                        };
+                } }
 
         public int Index => _index;
 
@@ -212,19 +213,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => mapFunc(AsT0),
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return mapFunc(AsT0);
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, TResult, T2, T3, T4, T5, T6, T7, T8> MapT1<TResult>(Func<T1, TResult> mapFunc)
@@ -233,19 +234,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => mapFunc(AsT1),
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return mapFunc(AsT1);
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, TResult, T3, T4, T5, T6, T7, T8> MapT2<TResult>(Func<T2, TResult> mapFunc)
@@ -254,19 +255,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => mapFunc(AsT2),
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return mapFunc(AsT2);
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, TResult, T4, T5, T6, T7, T8> MapT3<TResult>(Func<T3, TResult> mapFunc)
@@ -275,19 +276,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => mapFunc(AsT3),
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return mapFunc(AsT3);
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, TResult, T5, T6, T7, T8> MapT4<TResult>(Func<T4, TResult> mapFunc)
@@ -296,19 +297,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => mapFunc(AsT4),
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return mapFunc(AsT4);
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, TResult, T6, T7, T8> MapT5<TResult>(Func<T5, TResult> mapFunc)
@@ -317,19 +318,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => mapFunc(AsT5),
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return mapFunc(AsT5);
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, TResult, T7, T8> MapT6<TResult>(Func<T6, TResult> mapFunc)
@@ -338,19 +339,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => mapFunc(AsT6),
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return mapFunc(AsT6);
+                case 7: return AsT7;
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, TResult, T8> MapT7<TResult>(Func<T7, TResult> mapFunc)
@@ -359,19 +360,19 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => mapFunc(AsT7),
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return mapFunc(AsT7);
+                case 8: return AsT8;
+                  default: throw new InvalidOperationException();
+            }
         }
             
         public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TResult> MapT8<TResult>(Func<T8, TResult> mapFunc)
@@ -380,207 +381,209 @@ namespace OneOf
             {
                 throw new ArgumentNullException(nameof(mapFunc));
             }
-            return _index switch
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => mapFunc(AsT8),
-                _ => throw new InvalidOperationException()
-            };
+                case 0: return AsT0;
+                case 1: return AsT1;
+                case 2: return AsT2;
+                case 3: return AsT3;
+                case 4: return AsT4;
+                case 5: return AsT5;
+                case 6: return AsT6;
+                case 7: return AsT7;
+                case 8: return mapFunc(AsT8);
+                  default: throw new InvalidOperationException();
+            }
         }
 
-		public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT0 ? AsT0 : default;
-            remainder = _index switch
+        public bool TryPickT0(out T0 value, out OneOf<T1, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT0 ? AsT0 : default;
+            switch (_index)
             {
-                0 => default,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT0;
-		}
+                case 0: { remainder = default; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT0;
+        }
         
-		public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT1 ? AsT1 : default;
-            remainder = _index switch
+        public bool TryPickT1(out T1 value, out OneOf<T0, T2, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT1 ? AsT1 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => default,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT1;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = default; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT1;
+        }
         
-		public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT2 ? AsT2 : default;
-            remainder = _index switch
+        public bool TryPickT2(out T2 value, out OneOf<T0, T1, T3, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT2 ? AsT2 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => default,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT2;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = default; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT2;
+        }
         
-		public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
-		{
-			value = IsT3 ? AsT3 : default;
-            remainder = _index switch
+        public bool TryPickT3(out T3 value, out OneOf<T0, T1, T2, T4, T5, T6, T7, T8> remainder)
+        {
+            value = IsT3 ? AsT3 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => default,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT3;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = default; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT3;
+        }
         
-		public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
-		{
-			value = IsT4 ? AsT4 : default;
-            remainder = _index switch
+        public bool TryPickT4(out T4 value, out OneOf<T0, T1, T2, T3, T5, T6, T7, T8> remainder)
+        {
+            value = IsT4 ? AsT4 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => default,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT4;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = default; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT4;
+        }
         
-		public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
-		{
-			value = IsT5 ? AsT5 : default;
-            remainder = _index switch
+        public bool TryPickT5(out T5 value, out OneOf<T0, T1, T2, T3, T4, T6, T7, T8> remainder)
+        {
+            value = IsT5 ? AsT5 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => default,
-                6 => AsT6,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT5;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = default; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT5;
+        }
         
-		public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
-		{
-			value = IsT6 ? AsT6 : default;
-            remainder = _index switch
+        public bool TryPickT6(out T6 value, out OneOf<T0, T1, T2, T3, T4, T5, T7, T8> remainder)
+        {
+            value = IsT6 ? AsT6 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => default,
-                7 => AsT7,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT6;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = default; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT6;
+        }
         
-		public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
-		{
-			value = IsT7 ? AsT7 : default;
-            remainder = _index switch
+        public bool TryPickT7(out T7 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T8> remainder)
+        {
+            value = IsT7 ? AsT7 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => default,
-                8 => AsT8,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT7;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = default; break; }
+                case 8: { remainder = AsT8; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT7;
+        }
         
-		public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
-		{
-			value = IsT8 ? AsT8 : default;
-            remainder = _index switch
+        public bool TryPickT8(out T8 value, out OneOf<T0, T1, T2, T3, T4, T5, T6, T7> remainder)
+        {
+            value = IsT8 ? AsT8 : default;
+            switch (_index)
             {
-                0 => AsT0,
-                1 => AsT1,
-                2 => AsT2,
-                3 => AsT3,
-                4 => AsT4,
-                5 => AsT5,
-                6 => AsT6,
-                7 => AsT7,
-                8 => default,
-                _ => throw new InvalidOperationException()
-            };
-			return this.IsT8;
-		}
+                case 0: { remainder = AsT0; break; }
+                case 1: { remainder = AsT1; break; }
+                case 2: { remainder = AsT2; break; }
+                case 3: { remainder = AsT3; break; }
+                case 4: { remainder = AsT4; break; }
+                case 5: { remainder = AsT5; break; }
+                case 6: { remainder = AsT6; break; }
+                case 7: { remainder = AsT7; break; }
+                case 8: { remainder = default; break; }
+                default: throw new InvalidOperationException();
+            }
+            return this.IsT8;
+        }
 
-        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other) =>
-            _index == other._index &&
-            _index switch
+        bool Equals(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> other) {
+            var check1 = _index == other._index;
+            if (!check1) { return false; }
+            switch (_index)
             {
-                0 => Equals(_value0, other._value0),
-                1 => Equals(_value1, other._value1),
-                2 => Equals(_value2, other._value2),
-                3 => Equals(_value3, other._value3),
-                4 => Equals(_value4, other._value4),
-                5 => Equals(_value5, other._value5),
-                6 => Equals(_value6, other._value6),
-                7 => Equals(_value7, other._value7),
-                8 => Equals(_value8, other._value8),
-                _ => false
+                case 0: return check1 && Equals(_value0, other._value0);
+                             case 1: return check1 && Equals(_value1, other._value1);
+                             case 2: return check1 && Equals(_value2, other._value2);
+                             case 3: return check1 && Equals(_value3, other._value3);
+                             case 4: return check1 && Equals(_value4, other._value4);
+                             case 5: return check1 && Equals(_value5, other._value5);
+                             case 6: return check1 && Equals(_value6, other._value6);
+                             case 7: return check1 && Equals(_value7, other._value7);
+                             case 8: return check1 && Equals(_value8, other._value8);
+                default: return false;
             };
+                             }
 
         public override bool Equals(object obj)
         {
@@ -592,37 +595,39 @@ namespace OneOf
             return obj is OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> o && Equals(o);
         }
 
-        public override string ToString() =>
-            _index switch {
-                0 => FormatValue(_value0),
-                1 => FormatValue(_value1),
-                2 => FormatValue(_value2),
-                3 => FormatValue(_value3),
-                4 => FormatValue(_value4),
-                5 => FormatValue(_value5),
-                6 => FormatValue(_value6),
-                7 => FormatValue(_value7),
-                8 => FormatValue(_value8),
-                _ => throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.")
-            };
+        public override string ToString() {
+            switch (_index) {
+                case 0: return FormatValue(_value0);
+                case 1: return FormatValue(_value1);
+                case 2: return FormatValue(_value2);
+                case 3: return FormatValue(_value3);
+                case 4: return FormatValue(_value4);
+                case 5: return FormatValue(_value5);
+                case 6: return FormatValue(_value6);
+                case 7: return FormatValue(_value7);
+                case 8: return FormatValue(_value8);
+                default: throw new InvalidOperationException("Unexpected index, which indicates a problem in the OneOf codegen.");
+            }
+                                 }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                int hashCode = _index switch
+                    int hashCode;
+                    switch (_index)
                 {
-                    0 => _value0?.GetHashCode(),
-                    1 => _value1?.GetHashCode(),
-                    2 => _value2?.GetHashCode(),
-                    3 => _value3?.GetHashCode(),
-                    4 => _value4?.GetHashCode(),
-                    5 => _value5?.GetHashCode(),
-                    6 => _value6?.GetHashCode(),
-                    7 => _value7?.GetHashCode(),
-                    8 => _value8?.GetHashCode(),
-                    _ => 0
-                } ?? 0;
+                    case 0: { hashCode = _value0?.GetHashCode() ?? 0; break; }
+                    case 1: { hashCode = _value1?.GetHashCode() ?? 0; break; }
+                    case 2: { hashCode = _value2?.GetHashCode() ?? 0; break; }
+                    case 3: { hashCode = _value3?.GetHashCode() ?? 0; break; }
+                    case 4: { hashCode = _value4?.GetHashCode() ?? 0; break; }
+                    case 5: { hashCode = _value5?.GetHashCode() ?? 0; break; }
+                    case 6: { hashCode = _value6?.GetHashCode() ?? 0; break; }
+                    case 7: { hashCode = _value7?.GetHashCode() ?? 0; break; }
+                    case 8: { hashCode = _value8?.GetHashCode() ?? 0; break; }
+                    default: { hashCode = 0; break; }
+                }
                 return (hashCode*397) ^ _index;
             }
         }


### PR DESCRIPTION
Updated the generator to be compliant with C# versions below 8, which do not support switch expressions. I'm not sure what (if any) performance issues there may be w/ that change, but it seems like it's strictly better to be more compatible than not over using language features.

This exact issue came up for me as I was attempting to use `OneOf` in Unity, which doesn't support version 8.

As a bonus, I also updated the generator to use system paths so it's compatible w/ non-Windows systems.