### PR TITLE
OneOfBase hierarchies Source Generator

### DIFF
--- a/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
+++ b/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OneOf\OneOf.csproj" />
+    <ProjectReference Include="..\OneOf.SourceGenerator\OneOf.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -66,13 +66,28 @@ namespace OneOf.SourceGenerator.Tests
 
             Assert.Equal(testClass, test);
         }
+
+        [Fact]
+        public void GenerateOneOf_Works_With_Class_Names_Conflicts()
+        {
+            NotOneOf.OneOf notOneOf = new();
+
+            MyClassOrFakeOneOf myClass2OrFakeOneOf = notOneOf;
+
+            NotOneOf.OneOf test = myClass2OrFakeOneOf;
+
+            Assert.Equal(notOneOf, test);
+        }
     }
 
     [GenerateOneOf]
-    public partial class StringOrNumber : OneOf.OneOfBase<System.String, System.Int32, System.UInt32> { }
+    public partial class StringOrNumber : OneOfBase<string, int, uint> { }
 
     [GenerateOneOf]
-    public partial class MyClass2OrMyClass : OneOf.OneOfBase<MyClass, MyClass2> { }
+    public partial class MyClass2OrMyClass : OneOfBase<MyClass, MyClass2> { }
+
+    [GenerateOneOf]
+    public partial class MyClassOrFakeOneOf : OneOfBase<MyClass, NotOneOf.OneOf> { }
 
     public class MyClass
     {
@@ -80,6 +95,14 @@ namespace OneOf.SourceGenerator.Tests
     }
 
     public class MyClass2
+    {
+
+    }
+}
+
+namespace NotOneOf
+{
+    public class OneOf
     {
 
     }

--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -19,8 +19,8 @@ namespace OneOf.SourceGenerator.Tests
             stringOrNumber = testNumber;
             stringOrNumberToCompare = testNumber;
 
-            Assert.Equal<int>(testNumber, stringOrNumber);
-            Assert.True(testNumber == stringOrNumber);
+            Assert.Equal(testNumber, (int)stringOrNumber);
+            Assert.True(testNumber == (int)stringOrNumber);
             Assert.Equal(stringOrNumberToCompare, stringOrNumber);
         }
 
@@ -31,7 +31,7 @@ namespace OneOf.SourceGenerator.Tests
 
             StringOrNumber stringOrNumber = testName;
 
-            string name = stringOrNumber;
+            string name = (string)stringOrNumber;
 
             Assert.Equal(testName, name);
         }
@@ -45,14 +45,14 @@ namespace OneOf.SourceGenerator.Tests
             MyClass2OrMyClass myClass2OrMyClass = testclass;
             MyClass2OrMyClass myClass2OrMyClassToCompare = testclass;
 
-            Assert.Equal<MyClass>(testclass, myClass2OrMyClass);
-            Assert.Equal<MyClass>(myClass2OrMyClass, myClass2OrMyClassToCompare);
+            Assert.Equal(testclass, (MyClass)myClass2OrMyClass);
+            Assert.Equal((MyClass)myClass2OrMyClass, (MyClass)myClass2OrMyClassToCompare);
 
             myClass2OrMyClass = testclass2;
             myClass2OrMyClassToCompare = testclass2;
 
-            Assert.Equal<MyClass2>(testclass2, myClass2OrMyClass);
-            Assert.Equal<MyClass2>(myClass2OrMyClass, myClass2OrMyClassToCompare);
+            Assert.Equal(testclass2, (MyClass2)myClass2OrMyClass);
+            Assert.Equal((MyClass2)myClass2OrMyClass, (MyClass2)myClass2OrMyClassToCompare);
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace OneOf.SourceGenerator.Tests
 
             MyClass2OrMyClass myClass2OrMyClass = testClass;
 
-            MyClass test = myClass2OrMyClass;
+            var test = (MyClass)myClass2OrMyClass;
 
             Assert.Equal(testClass, test);
         }
@@ -74,7 +74,7 @@ namespace OneOf.SourceGenerator.Tests
 
             MyClassOrFakeOneOf myClass2OrFakeOneOf = notOneOf;
 
-            NotOneOf.OneOf test = myClass2OrFakeOneOf;
+            var test = (NotOneOf.OneOf)myClass2OrFakeOneOf;
 
             Assert.Equal(notOneOf, test);
         }

--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace OneOf.SourceGenerator.Tests
+{
+    public class SourceGeneratorTests
+    {
+        [Fact]
+        public void GenerateOneOf_Generates_Correct_Classes_For_Simple_Types()
+        {
+            const string testName = "test";
+            StringOrNumber stringOrNumber = testName;
+            StringOrNumber stringOrNumberToCompare = testName;
+
+            Assert.Equal(testName, stringOrNumber);
+            Assert.Equal(stringOrNumberToCompare, stringOrNumber);
+        }
+
+    }
+
+    [GenerateOneOf]
+    public partial class StringOrNumber : OneOf.OneOfBase<System.String, System.Int32, System.UInt32> { }
+}

--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -5,18 +5,82 @@ namespace OneOf.SourceGenerator.Tests
     public class SourceGeneratorTests
     {
         [Fact]
-        public void GenerateOneOf_Generates_Correct_Classes_For_Simple_Types()
+        public void GenerateOneOf_Generates_Correct_Classes_For_Struct_Types()
         {
             const string testName = "test";
+            const int testNumber = 3;
+
             StringOrNumber stringOrNumber = testName;
             StringOrNumber stringOrNumberToCompare = testName;
 
             Assert.Equal(testName, stringOrNumber);
             Assert.Equal(stringOrNumberToCompare, stringOrNumber);
+
+            stringOrNumber = testNumber;
+            stringOrNumberToCompare = testNumber;
+
+            Assert.Equal<int>(testNumber, stringOrNumber);
+            Assert.True(testNumber == stringOrNumber);
+            Assert.Equal(stringOrNumberToCompare, stringOrNumber);
         }
 
+        [Fact]
+        public void GenerateOneOf_Can_Assign_To_Struct_Type()
+        {
+            const string testName = "test";
+
+            StringOrNumber stringOrNumber = testName;
+
+            string name = stringOrNumber;
+
+            Assert.Equal(testName, name);
+        }
+
+        [Fact]
+        public void GenerateOneOf_Generates_Correct_Classes_For_Referance_Types()
+        {
+            MyClass testclass = new();
+            MyClass2 testclass2 = new();
+
+            MyClass2OrMyClass myClass2OrMyClass = testclass;
+            MyClass2OrMyClass myClass2OrMyClassToCompare = testclass;
+
+            Assert.Equal<MyClass>(testclass, myClass2OrMyClass);
+            Assert.Equal<MyClass>(myClass2OrMyClass, myClass2OrMyClassToCompare);
+
+            myClass2OrMyClass = testclass2;
+            myClass2OrMyClassToCompare = testclass2;
+
+            Assert.Equal<MyClass2>(testclass2, myClass2OrMyClass);
+            Assert.Equal<MyClass2>(myClass2OrMyClass, myClass2OrMyClassToCompare);
+        }
+
+        [Fact]
+        public void GenerateOneOf_Can_Assign_To_Referance_Type()
+        {
+            MyClass testClass = new();
+
+            MyClass2OrMyClass myClass2OrMyClass = testClass;
+
+            MyClass test = myClass2OrMyClass;
+
+            Assert.Equal(testClass, test);
+        }
     }
 
     [GenerateOneOf]
     public partial class StringOrNumber : OneOf.OneOfBase<System.String, System.Int32, System.UInt32> { }
+
+    [GenerateOneOf]
+    public partial class MyClass2OrMyClass : OneOf.OneOfBase<MyClass, MyClass2> { }
+
+    public class MyClass
+    {
+
+    }
+
+    public class MyClass2
+    {
+
+    }
 }

--- a/OneOf.SourceGenerator/ITypeSymbolExtensions.cs
+++ b/OneOf.SourceGenerator/ITypeSymbolExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace OneOf.SourceGenerator
+{
+    public static class ITypeSymbolExtensions
+    {
+        public static string GetFullName(this ITypeSymbol type) => $"{(type.ContainingNamespace is object ? $"{type.ContainingNamespace}." : string.Empty)}{type.Name}";
+    }
+}

--- a/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
+++ b/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
+++ b/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
@@ -1,10 +1,30 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Harry McIntyre, Damian Romanowski</Authors>
+    <Title>OneOf - Easy Discriminated Unions for c#</Title>
+    <Company>Harry McIntyre</Company>
+    <PackageVersion>1.0.0</PackageVersion>
+    <Product>Harry McIntyre</Product>
+    <Description>This source generator automaticly implements OneOfBase hierarchies</Description>
+    <PackageProjectUrl>https://github.com/mcintyre321/OneOf/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/mcintyre321/OneOf/blob/master/licence.md</PackageLicenseUrl>
+    <PackageTags>discriminated unions, return type, match switch, generator, source generator</PackageTags>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PackageId>OneOf.SourceGenerator</PackageId>
+    <Copyright>Harry McIntyre</Copyright>
+    <RootNamespace>OneOf</RootNamespace>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Text;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -93,13 +92,6 @@ namespace {_attributeNamespace}
                 }
             }
 
-#if DEBUG
-            if (!Debugger.IsAttached)
-            {
-                //Debugger.Launch();
-            }
-#endif
-
             foreach (INamedTypeSymbol namedSymnbol in namedTypeSymbols)
             {
                 string? classSource = ProcessClass(namedSymnbol, context);
@@ -146,12 +138,11 @@ namespace {_attributeNamespace}
 
             string generics = string.Join(", ", typeArguments.Select(x => x.GetFullName()));
 
-            //Partial declarations of '...' must not specify different base classes?
             StringBuilder source = new($@"using System;
 
 namespace {classSymbol.ContainingNamespace.ToDisplayString()}
 {{
-    public partial class {classSymbol.Name} //: OneOf.OneOfBase<{generics}>
+    public partial class {classSymbol.Name}
     {{
         public {classSymbol.Name}(OneOf.OneOf<{generics}> _) : base(_) {{ }}
 ");
@@ -164,26 +155,7 @@ namespace {classSymbol.ContainingNamespace.ToDisplayString()}
 ");
             }
 
-            source.Append($@"
-        //public override bool Equals(object obj) => ReferenceEquals(this, obj) || Equals(obj as {classSymbol.Name});
-
-	    //public bool Equals({classSymbol.Name}? other)
-	    //{{
-		   // if (ReferenceEquals(null, other))
-		   // {{
-			  //  return false;
-		   // }}
-		   // if (ReferenceEquals(this, other))
-		   // {{
-			  //  return true;
-		   // }}
-		
-		   // return Value.Equals(other.Value);
-	    //}}
-
-	    //public static bool operator ==({classSymbol.Name} left, {classSymbol.Name} right) => Equals(left, right);
-	    //public static bool operator !=({classSymbol.Name} left, {classSymbol.Name} right) => !Equals(left, right);
-    }}
+            source.Append($@"    }}
 }}");
             return source.ToString();
         }

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -146,11 +146,12 @@ namespace {_attributeNamespace}
 
             string generics = string.Join(", ", typeArguments.Select(x => x.GetFullName()));
 
+            //Partial declarations of '...' must not specify different base classes?
             StringBuilder source = new($@"using System;
 
 namespace {classSymbol.ContainingNamespace.ToDisplayString()}
 {{
-    public partial class {classSymbol.Name} : OneOf.OneOfBase<{generics}>
+    public partial class {classSymbol.Name} //: OneOf.OneOfBase<{generics}>
     {{
         public {classSymbol.Name}(OneOf.OneOf<{generics}> _) : base(_) {{ }}
 ");
@@ -180,8 +181,8 @@ namespace {classSymbol.ContainingNamespace.ToDisplayString()}
 		   // return Value.Equals(other.Value);
 	    //}}
 
-	    public static bool operator ==({classSymbol.Name} left, {classSymbol.Name} right) => Equals(left, right);
-	    public static bool operator !=({classSymbol.Name} left, {classSymbol.Name} right) => !Equals(left, right);
+	    //public static bool operator ==({classSymbol.Name} left, {classSymbol.Name} right) => Equals(left, right);
+	    //public static bool operator !=({classSymbol.Name} left, {classSymbol.Name} right) => !Equals(left, right);
     }}
 }}");
             return source.ToString();

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -1,0 +1,208 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace OneOf.SourceGenerator
+{
+    [Generator]
+    public class OneOfGenerator : ISourceGenerator
+    {
+
+        private static readonly DiagnosticDescriptor _topLevelError = new(id: "ONEOFGEN001",
+                                                                                              title: "Class must be top level",
+                                                                                              messageFormat: "Class '{0}' using OneOfGenerator must be top level",
+                                                                                              category: "OneOfGenerator",
+                                                                                              DiagnosticSeverity.Error,
+                                                                                              isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor _wrongBaseType = new(id: "ONEOFGEN002",
+                                                                                              title: "Class must inherit from OneOfBase",
+                                                                                              messageFormat: "Class '{0}' does not inherit from OneOfBase",
+                                                                                              category: "OneOfGenerator",
+                                                                                              DiagnosticSeverity.Error,
+                                                                                              isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor _classIsNotPublic = new(id: "ONEOFGEN003",
+                                                                                              title: "Class must be public",
+                                                                                              messageFormat: "Class '{0}' is not public",
+                                                                                              category: "OneOfGenerator",
+                                                                                              DiagnosticSeverity.Error,
+                                                                                              isEnabledByDefault: true);
+
+        private static readonly DiagnosticDescriptor _objectIsOneOfType = new(id: "ONEOFGEN004",
+                                                                                              title: "Object is not a valid type parameter",
+                                                                                              messageFormat: "Defined conversions to or from a base type are not allowed for class '{0}'",
+                                                                                              category: "OneOfGenerator",
+                                                                                              DiagnosticSeverity.Error,
+                                                                                              isEnabledByDefault: true);
+
+        private const string _attributeName = "GenerateOneOfAttribute";
+        private const string _attributeNamespace = "OneOf";
+        private readonly string _attributeText = $@"using System;
+
+namespace {_attributeNamespace}
+{{
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    public sealed class {_attributeName} : Attribute
+    {{
+    }}
+}}
+        ";
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            context.AddSource(_attributeName, SourceText.From(_attributeText, Encoding.UTF8));
+
+            if (context.SyntaxReceiver is not OneOfSyntaxReceiver receiver)
+            {
+                return;
+            }
+
+            if ((context.Compilation as CSharpCompilation)?.SyntaxTrees[0].Options is not CSharpParseOptions options)
+            {
+                return;
+            }
+
+            Compilation compilation = context.Compilation.AddSyntaxTrees(CSharpSyntaxTree.ParseText(SourceText.From(_attributeText, Encoding.UTF8), options));
+
+            INamedTypeSymbol? attributeSymbol = compilation.GetTypeByMetadataName($"{_attributeNamespace}.{_attributeName}");
+
+            if (attributeSymbol is null)
+            {
+                return;
+            }
+
+            List<INamedTypeSymbol> namedTypeSymbols = new();
+            foreach (ClassDeclarationSyntax classDeclaration in receiver.CandidateClasses)
+            {
+                SemanticModel model = compilation.GetSemanticModel(classDeclaration.SyntaxTree);
+                INamedTypeSymbol? namedTypeSymbol = model.GetDeclaredSymbol(classDeclaration);
+
+                AttributeData? attributeData = namedTypeSymbol?.GetAttributes().FirstOrDefault(ad => ad.AttributeClass?.Equals(attributeSymbol, SymbolEqualityComparer.Default) != false);
+
+                if (attributeData is object)
+                {
+                    namedTypeSymbols.Add(namedTypeSymbol!);
+                }
+            }
+
+#if DEBUG
+            if (!Debugger.IsAttached)
+            {
+                //Debugger.Launch();
+            }
+#endif
+
+            foreach (INamedTypeSymbol namedSymnbol in namedTypeSymbols)
+            {
+                string? classSource = ProcessClass(namedSymnbol, context);
+
+                if (classSource is null)
+                {
+                    continue;
+                }
+
+                context.AddSource($"{namedSymnbol.ContainingNamespace}_{namedSymnbol.Name}.generated.cs", SourceText.From(classSource, Encoding.UTF8));
+            }
+        }
+
+        private string? ProcessClass(INamedTypeSymbol classSymbol, GeneratorExecutionContext context)
+        {
+            if (!classSymbol.ContainingSymbol.Equals(classSymbol.ContainingNamespace, SymbolEqualityComparer.Default))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(_topLevelError, Location.None, classSymbol.Name));
+                return null;
+            }
+
+            if (classSymbol.BaseType is null || classSymbol.BaseType.Name != "OneOfBase" || classSymbol.BaseType.ContainingNamespace.ToString() != "OneOf")
+            {
+                context.ReportDiagnostic(Diagnostic.Create(_wrongBaseType, Location.None, classSymbol.Name));
+                return null;
+            }
+
+            if (classSymbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(_classIsNotPublic, Location.None, classSymbol.Name));
+                return null;
+            }
+
+            ImmutableArray<ITypeParameterSymbol> typeParameters = classSymbol.BaseType.TypeParameters;
+            ImmutableArray<ITypeSymbol> typeArguments = classSymbol.BaseType.TypeArguments;
+
+            if (typeArguments.Any(x => x.Name == nameof(Object)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(_objectIsOneOfType, Location.None, classSymbol.Name));
+                return null;
+            }
+
+            IEnumerable<(ITypeParameterSymbol param, ITypeSymbol arg)> paramArgPairs = typeParameters.Zip(typeArguments, (param, arg) => (param, arg));
+
+            string generics = string.Join(", ", typeArguments.Select(x => x.GetFullName()));
+
+            StringBuilder source = new($@"using System;
+
+namespace {classSymbol.ContainingNamespace.ToDisplayString()}
+{{
+    public partial class {classSymbol.Name} : OneOf.OneOfBase<{generics}>
+    {{
+        public {classSymbol.Name}(OneOf.OneOf<{generics}> _) : base(_) {{ }}
+");
+
+            foreach ((ITypeParameterSymbol param, ITypeSymbol arg) in paramArgPairs)
+            {
+                source.Append($@"
+        public static implicit operator {classSymbol.Name}({arg.GetFullName()} _) => new {classSymbol.Name}(_);
+        public static implicit operator {arg.GetFullName()}({classSymbol.Name} _) => _.As{param.Name};
+");
+            }
+
+            source.Append($@"
+        //public override bool Equals(object obj) => ReferenceEquals(this, obj) || Equals(obj as {classSymbol.Name});
+
+	    //public bool Equals({classSymbol.Name}? other)
+	    //{{
+		   // if (ReferenceEquals(null, other))
+		   // {{
+			  //  return false;
+		   // }}
+		   // if (ReferenceEquals(this, other))
+		   // {{
+			  //  return true;
+		   // }}
+		
+		   // return Value.Equals(other.Value);
+	    //}}
+
+	    public static bool operator ==({classSymbol.Name} left, {classSymbol.Name} right) => Equals(left, right);
+	    public static bool operator !=({classSymbol.Name} left, {classSymbol.Name} right) => !Equals(left, right);
+    }}
+}}");
+            return source.ToString();
+        }
+
+        public void Initialize(GeneratorInitializationContext context)
+            => context.RegisterForSyntaxNotifications(() => new OneOfSyntaxReceiver());
+    }
+
+    class OneOfSyntaxReceiver : ISyntaxReceiver
+    {
+        public List<ClassDeclarationSyntax> CandidateClasses { get; } = new();
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is ClassDeclarationSyntax classDeclarationSyntax
+                && classDeclarationSyntax.AttributeLists.Count > 0 &&
+                classDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                CandidateClasses.Add(classDeclarationSyntax);
+            }
+        }
+    }
+}

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -153,7 +153,7 @@ namespace {classSymbol.ContainingNamespace.ToDisplayString()}
             {
                 source.Append($@"
         public static implicit operator {classSymbol.Name}({arg.GetFullName()} _) => new {classSymbol.Name}(_);
-        public static implicit operator {arg.GetFullName()}({classSymbol.Name} _) => _.As{param.Name};
+        public static explicit operator {arg.GetFullName()}({classSymbol.Name} _) => _.As{param.Name};
 ");
             }
 

--- a/OneOf.sln
+++ b/OneOf.sln
@@ -14,7 +14,11 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "OneOf.FSharp", "OneOf.FShar
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.Extended", "OneOf.Extended\OneOf.Extended.csproj", "{FB8845F4-51F1-407A-8E10-2A0B892E17FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Generator", "Generator\Generator.csproj", "{508CDAF6-E780-459E-BD8F-776A5EE2C2FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Generator", "Generator\Generator.csproj", "{508CDAF6-E780-459E-BD8F-776A5EE2C2FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneOf.SourceGenerator", "OneOf.SourceGenerator\OneOf.SourceGenerator.csproj", "{AC54E93D-1DB2-4143-A1AF-3CE2492EAC83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneOf.SourceGenerator.Tests", "OneOf.SourceGenerator.Tests\OneOf.SourceGenerator.Tests.csproj", "{A7D18F0E-8966-4685-8146-34F507356F5D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,6 +46,14 @@ Global
 		{508CDAF6-E780-459E-BD8F-776A5EE2C2FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{508CDAF6-E780-459E-BD8F-776A5EE2C2FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{508CDAF6-E780-459E-BD8F-776A5EE2C2FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC54E93D-1DB2-4143-A1AF-3CE2492EAC83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC54E93D-1DB2-4143-A1AF-3CE2492EAC83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC54E93D-1DB2-4143-A1AF-3CE2492EAC83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC54E93D-1DB2-4143-A1AF-3CE2492EAC83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7D18F0E-8966-4685-8146-34F507356F5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7D18F0E-8966-4685-8146-34F507356F5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7D18F0E-8966-4685-8146-34F507356F5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7D18F0E-8966-4685-8146-34F507356F5D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -168,3 +168,26 @@ x = "abcd";
 Console.WriteLine(x.TryGetNumber().isNumber);
 // prints False
 ```
+
+### GenerateOneOf attribute
+
+You can automatically generate OneOfBase hierarchies using `GenerateOneOfAttribute` and partial class that extends `OneOfBase`
+
+```csharp
+[GenerateOneOf]
+public partial class StringOrNumber : OneOfBase<string, int> { }
+```
+
+During compilation `OneOfGenerator` will produce a class with all implicit operators already generated
+```
+public partial class StringOrNumber
+    {
+        public StringOrNumber(OneOf.OneOf<System.String, System.Int32> _) : base(_) { }
+
+        public static implicit operator StringOrNumber(System.String _) => new StringOrNumber(_);
+        public static implicit operator System.String(StringOrNumber _) => _.AsT0;
+
+        public static implicit operator StringOrNumber(System.Int32 _) => new StringOrNumber(_);
+        public static implicit operator System.Int32(StringOrNumber _) => _.AsT1;
+    }
+```

--- a/README.md
+++ b/README.md
@@ -178,16 +178,16 @@ You can automatically generate `OneOfBase` hierarchies using `GenerateOneOfAttri
 public partial class StringOrNumber : OneOfBase<string, int> { }
 ```
 
-During compilation `OneOfGenerator` will produce a class with all implicit operators already generated
+During compilation `OneOfGenerator` will produce a class with implicit and explicit operators already generated
 ```csharp
 public partial class StringOrNumber
 {
 	public StringOrNumber(OneOf.OneOf<System.String, System.Int32> _) : base(_) { }
 
 	public static implicit operator StringOrNumber(System.String _) => new StringOrNumber(_);
-	public static implicit operator System.String(StringOrNumber _) => _.AsT0;
+	public static explicit operator System.String(StringOrNumber _) => _.AsT0;
 
 	public static implicit operator StringOrNumber(System.Int32 _) => new StringOrNumber(_);
-	public static implicit operator System.Int32(StringOrNumber _) => _.AsT1;
+	public static explicit operator System.Int32(StringOrNumber _) => _.AsT1;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can automatically generate `OneOfBase` hierarchies using `GenerateOneOfAttri
 ```csharp
 [GenerateOneOf]
 public partial class StringOrNumber : OneOfBase<string, int> { }
-```csharp
+```
 
 During compilation `OneOfGenerator` will produce a class with all implicit operators already generated
 ```csharp

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Console.WriteLine(x.TryGetNumber().isNumber);
 
 ### GenerateOneOf attribute
 
-You can automatically generate OneOfBase hierarchies using `GenerateOneOfAttribute` and partial class that extends `OneOfBase`
+You can automatically generate `OneOfBase` hierarchies using `GenerateOneOfAttribute` and partial class that extends `OneOfBase`
 
 ```csharp
 [GenerateOneOf]
@@ -179,15 +179,15 @@ public partial class StringOrNumber : OneOfBase<string, int> { }
 ```
 
 During compilation `OneOfGenerator` will produce a class with all implicit operators already generated
-```
+```csharp
 public partial class StringOrNumber
-    {
-        public StringOrNumber(OneOf.OneOf<System.String, System.Int32> _) : base(_) { }
+{
+	public StringOrNumber(OneOf.OneOf<System.String, System.Int32> _) : base(_) { }
 
-        public static implicit operator StringOrNumber(System.String _) => new StringOrNumber(_);
-        public static implicit operator System.String(StringOrNumber _) => _.AsT0;
+	public static implicit operator StringOrNumber(System.String _) => new StringOrNumber(_);
+	public static implicit operator System.String(StringOrNumber _) => _.AsT0;
 
-        public static implicit operator StringOrNumber(System.Int32 _) => new StringOrNumber(_);
-        public static implicit operator System.Int32(StringOrNumber _) => _.AsT1;
-    }
+	public static implicit operator StringOrNumber(System.Int32 _) => new StringOrNumber(_);
+	public static implicit operator System.Int32(StringOrNumber _) => _.AsT1;
+}
 ```


### PR DESCRIPTION
resolves #75 
Implementation of OneOf source generator, which for class definition like:

```csharp
[GenerateOneOf]
public partial class StringOrNumber : OneOfBase<string, int> { }
```

will generate matching class with implicit and explicit operators added:
```csharp
public partial class StringOrNumber
{
	public StringOrNumber(OneOf.OneOf<System.String, System.Int32> _) : base(_) { }

	public static implicit operator StringOrNumber(System.String _) => new StringOrNumber(_);
	public static explicit operator System.String(StringOrNumber _) => _.AsT0;

	public static implicit operator StringOrNumber(System.Int32 _) => new StringOrNumber(_);
	public static explicit operator System.Int32(StringOrNumber _) => _.AsT1;
}
```