### PR TITLE
source gen: fixed nested generics

### DIFF
--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Xunit;
 
 namespace OneOf.SourceGenerator.Tests
@@ -78,7 +79,36 @@ namespace OneOf.SourceGenerator.Tests
 
             Assert.Equal(notOneOf, test);
         }
+
+        [Fact]
+        public void GenerateOneOf_Works_With_Simple_Generic_Types()
+        {
+            SimpleGeneric simple1 = new List<string> { "a", "b", "c" };
+            Assert.True(simple1.IsT0);
+
+            SimpleGeneric simple2 = new List<int> { 1, 2, 3 };
+            Assert.True(simple2.IsT1);
+
+            SimpleGeneric simple3 = new Dictionary<long, string> { { 1, "a" }, { 2, "b" }, { 3, "c" } };
+            Assert.True(simple3.IsT2);
+        }
+
+        [Fact]
+        public void GenerateOneOf_Works_With_Nested_Generics()
+        {
+            NestedGeneric nested1 = new List<List<string>> { new() { "a", "b", "c" } };
+            Assert.True(nested1.IsT0);
+
+            NestedGeneric nested2 = new Dictionary<List<string>, string> { { new List<string> { "a", "b", "c" }, "d" } };
+            Assert.True(nested2.IsT2);
+        }
     }
+
+    [GenerateOneOf]
+    public partial class NestedGeneric : OneOfBase<List<List<string>>, List<int>, Dictionary<List<string>, string>> { }
+
+    [GenerateOneOf]
+    public partial class SimpleGeneric : OneOfBase<List<string>, List<int>, Dictionary<long, string>> { }
 
     [GenerateOneOf]
     public partial class StringOrNumber : OneOfBase<string, int, uint> { }

--- a/OneOf.SourceGenerator/ITypeSymbolExtensions.cs
+++ b/OneOf.SourceGenerator/ITypeSymbolExtensions.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.CodeAnalysis;
-
-namespace OneOf.SourceGenerator
-{
-    public static class ITypeSymbolExtensions
-    {
-        public static string GetFullName(this ITypeSymbol type) => $"{(type.ContainingNamespace is object ? $"{type.ContainingNamespace}." : string.Empty)}{type.Name}";
-    }
-}


### PR DESCRIPTION
currently for class like:
```csharp
[GenerateOneOf]
 public partial class Test: OneOfBase<bool, List<long>>
 {
 }
```
generated partial will not be correct:
```csharp
public partial class Test
{
    public Test(OneOf.OneOf<System.Boolean, System.Collections.Generic.List> _) : base(_) { }

    public static implicit operator Test(System.Boolean _) => new Test(_);
    public static explicit operator System.Boolean(Test _) => _.AsT0;

    public static implicit operator Test(System.Collections.Generic.List _) => new Test(_);
    public static explicit operator System.Collections.Generic.List(Test _) => _.AsT1;
}
```
I've fixed it in this pr.
