### PR TITLE
Add .NET Standard 2.0 target to avoid NETStandard.Library dependency

### DIFF
--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
     <Company>Harry McIntyre</Company>


### PR DESCRIPTION
Closes #101 