### PR TITLE
Added overload to switch method for use with async code.

### DIFF
--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -38,6 +38,10 @@ string GetContent(bool isStruct, int i) {
     var sb = new StringBuilder();
 
     sb.Append(@$"using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -99,6 +103,18 @@ namespace OneOf
             }}")}
             throw new InvalidOperationException();
         }}
+
+#if !NET35
+        public Task Switch({RangeJoined(", ", e => $"Func<T{e}, Task> f{e}")})
+        {{
+            {RangeJoined(@"
+            ", j => @$"if (_index == {j} && f{j} != null)
+            {{                
+                return f{j}(_value{j});
+            }}")}
+            throw new InvalidOperationException();
+        }}
+#endif
 
         public TResult Match<TResult>({RangeJoined(", ", e => $"Func<T{e}, TResult> f{e}")})
         {{

--- a/OneOf.Extended/OneOfBaseT10.generated.cs
+++ b/OneOf.Extended/OneOfBaseT10.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -175,6 +179,57 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10)
         {

--- a/OneOf.Extended/OneOfBaseT11.generated.cs
+++ b/OneOf.Extended/OneOfBaseT11.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -188,6 +192,61 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11)
         {

--- a/OneOf.Extended/OneOfBaseT12.generated.cs
+++ b/OneOf.Extended/OneOfBaseT12.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -201,6 +205,65 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12)
         {

--- a/OneOf.Extended/OneOfBaseT13.generated.cs
+++ b/OneOf.Extended/OneOfBaseT13.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -214,6 +218,69 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13)
         {

--- a/OneOf.Extended/OneOfBaseT14.generated.cs
+++ b/OneOf.Extended/OneOfBaseT14.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -227,6 +231,73 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14)
         {

--- a/OneOf.Extended/OneOfBaseT15.generated.cs
+++ b/OneOf.Extended/OneOfBaseT15.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -240,6 +244,77 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15)
         {

--- a/OneOf.Extended/OneOfBaseT16.generated.cs
+++ b/OneOf.Extended/OneOfBaseT16.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -253,6 +257,81 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16)
         {

--- a/OneOf.Extended/OneOfBaseT17.generated.cs
+++ b/OneOf.Extended/OneOfBaseT17.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -266,6 +270,85 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17)
         {

--- a/OneOf.Extended/OneOfBaseT18.generated.cs
+++ b/OneOf.Extended/OneOfBaseT18.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -279,6 +283,89 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18)
         {

--- a/OneOf.Extended/OneOfBaseT19.generated.cs
+++ b/OneOf.Extended/OneOfBaseT19.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -292,6 +296,93 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19)
         {

--- a/OneOf.Extended/OneOfBaseT20.generated.cs
+++ b/OneOf.Extended/OneOfBaseT20.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -305,6 +309,97 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20)
         {

--- a/OneOf.Extended/OneOfBaseT21.generated.cs
+++ b/OneOf.Extended/OneOfBaseT21.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -318,6 +322,101 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21)
         {

--- a/OneOf.Extended/OneOfBaseT22.generated.cs
+++ b/OneOf.Extended/OneOfBaseT22.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -331,6 +335,105 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22)
         {

--- a/OneOf.Extended/OneOfBaseT23.generated.cs
+++ b/OneOf.Extended/OneOfBaseT23.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -344,6 +348,109 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23)
         {

--- a/OneOf.Extended/OneOfBaseT24.generated.cs
+++ b/OneOf.Extended/OneOfBaseT24.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -357,6 +361,113 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24)
         {

--- a/OneOf.Extended/OneOfBaseT25.generated.cs
+++ b/OneOf.Extended/OneOfBaseT25.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -370,6 +374,117 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25)
         {

--- a/OneOf.Extended/OneOfBaseT26.generated.cs
+++ b/OneOf.Extended/OneOfBaseT26.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -383,6 +387,121 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26)
         {

--- a/OneOf.Extended/OneOfBaseT27.generated.cs
+++ b/OneOf.Extended/OneOfBaseT27.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -396,6 +400,125 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27)
         {

--- a/OneOf.Extended/OneOfBaseT28.generated.cs
+++ b/OneOf.Extended/OneOfBaseT28.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -409,6 +413,129 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28)
         {

--- a/OneOf.Extended/OneOfBaseT29.generated.cs
+++ b/OneOf.Extended/OneOfBaseT29.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -422,6 +426,133 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29)
         {

--- a/OneOf.Extended/OneOfBaseT30.generated.cs
+++ b/OneOf.Extended/OneOfBaseT30.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -435,6 +439,137 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29, Func<T30, Task> f30)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            if (_index == 30 && f30 != null)
+            {                
+                return f30(_value30);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30)
         {

--- a/OneOf.Extended/OneOfBaseT31.generated.cs
+++ b/OneOf.Extended/OneOfBaseT31.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -448,6 +452,141 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29, Func<T30, Task> f30, Func<T31, Task> f31)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            if (_index == 30 && f30 != null)
+            {                
+                return f30(_value30);
+            }
+            if (_index == 31 && f31 != null)
+            {                
+                return f31(_value31);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30, Func<T31, TResult> f31)
         {

--- a/OneOf.Extended/OneOfBaseT9.generated.cs
+++ b/OneOf.Extended/OneOfBaseT9.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -162,6 +166,53 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9)
         {

--- a/OneOf.Extended/OneOfT10.generated.cs
+++ b/OneOf.Extended/OneOfT10.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -181,6 +185,57 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10)
         {

--- a/OneOf.Extended/OneOfT11.generated.cs
+++ b/OneOf.Extended/OneOfT11.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -195,6 +199,61 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11)
         {

--- a/OneOf.Extended/OneOfT12.generated.cs
+++ b/OneOf.Extended/OneOfT12.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -209,6 +213,65 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12)
         {

--- a/OneOf.Extended/OneOfT13.generated.cs
+++ b/OneOf.Extended/OneOfT13.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -223,6 +227,69 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13)
         {

--- a/OneOf.Extended/OneOfT14.generated.cs
+++ b/OneOf.Extended/OneOfT14.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -237,6 +241,73 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14)
         {

--- a/OneOf.Extended/OneOfT15.generated.cs
+++ b/OneOf.Extended/OneOfT15.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -251,6 +255,77 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15)
         {

--- a/OneOf.Extended/OneOfT16.generated.cs
+++ b/OneOf.Extended/OneOfT16.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -265,6 +269,81 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16)
         {

--- a/OneOf.Extended/OneOfT17.generated.cs
+++ b/OneOf.Extended/OneOfT17.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -279,6 +283,85 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17)
         {

--- a/OneOf.Extended/OneOfT18.generated.cs
+++ b/OneOf.Extended/OneOfT18.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -293,6 +297,89 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18)
         {

--- a/OneOf.Extended/OneOfT19.generated.cs
+++ b/OneOf.Extended/OneOfT19.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -307,6 +311,93 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19)
         {

--- a/OneOf.Extended/OneOfT20.generated.cs
+++ b/OneOf.Extended/OneOfT20.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -321,6 +325,97 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20)
         {

--- a/OneOf.Extended/OneOfT21.generated.cs
+++ b/OneOf.Extended/OneOfT21.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -335,6 +339,101 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21)
         {

--- a/OneOf.Extended/OneOfT22.generated.cs
+++ b/OneOf.Extended/OneOfT22.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -349,6 +353,105 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22)
         {

--- a/OneOf.Extended/OneOfT23.generated.cs
+++ b/OneOf.Extended/OneOfT23.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -363,6 +367,109 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23)
         {

--- a/OneOf.Extended/OneOfT24.generated.cs
+++ b/OneOf.Extended/OneOfT24.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -377,6 +381,113 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24)
         {

--- a/OneOf.Extended/OneOfT25.generated.cs
+++ b/OneOf.Extended/OneOfT25.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -391,6 +395,117 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25)
         {

--- a/OneOf.Extended/OneOfT26.generated.cs
+++ b/OneOf.Extended/OneOfT26.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -405,6 +409,121 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26)
         {

--- a/OneOf.Extended/OneOfT27.generated.cs
+++ b/OneOf.Extended/OneOfT27.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -419,6 +423,125 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27)
         {

--- a/OneOf.Extended/OneOfT28.generated.cs
+++ b/OneOf.Extended/OneOfT28.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -433,6 +437,129 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28)
         {

--- a/OneOf.Extended/OneOfT29.generated.cs
+++ b/OneOf.Extended/OneOfT29.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -447,6 +451,133 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29)
         {

--- a/OneOf.Extended/OneOfT30.generated.cs
+++ b/OneOf.Extended/OneOfT30.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -461,6 +465,137 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29, Func<T30, Task> f30)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            if (_index == 30 && f30 != null)
+            {                
+                return f30(_value30);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30)
         {

--- a/OneOf.Extended/OneOfT31.generated.cs
+++ b/OneOf.Extended/OneOfT31.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -475,6 +479,141 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9, Func<T10, Task> f10, Func<T11, Task> f11, Func<T12, Task> f12, Func<T13, Task> f13, Func<T14, Task> f14, Func<T15, Task> f15, Func<T16, Task> f16, Func<T17, Task> f17, Func<T18, Task> f18, Func<T19, Task> f19, Func<T20, Task> f20, Func<T21, Task> f21, Func<T22, Task> f22, Func<T23, Task> f23, Func<T24, Task> f24, Func<T25, Task> f25, Func<T26, Task> f26, Func<T27, Task> f27, Func<T28, Task> f28, Func<T29, Task> f29, Func<T30, Task> f30, Func<T31, Task> f31)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            if (_index == 10 && f10 != null)
+            {                
+                return f10(_value10);
+            }
+            if (_index == 11 && f11 != null)
+            {                
+                return f11(_value11);
+            }
+            if (_index == 12 && f12 != null)
+            {                
+                return f12(_value12);
+            }
+            if (_index == 13 && f13 != null)
+            {                
+                return f13(_value13);
+            }
+            if (_index == 14 && f14 != null)
+            {                
+                return f14(_value14);
+            }
+            if (_index == 15 && f15 != null)
+            {                
+                return f15(_value15);
+            }
+            if (_index == 16 && f16 != null)
+            {                
+                return f16(_value16);
+            }
+            if (_index == 17 && f17 != null)
+            {                
+                return f17(_value17);
+            }
+            if (_index == 18 && f18 != null)
+            {                
+                return f18(_value18);
+            }
+            if (_index == 19 && f19 != null)
+            {                
+                return f19(_value19);
+            }
+            if (_index == 20 && f20 != null)
+            {                
+                return f20(_value20);
+            }
+            if (_index == 21 && f21 != null)
+            {                
+                return f21(_value21);
+            }
+            if (_index == 22 && f22 != null)
+            {                
+                return f22(_value22);
+            }
+            if (_index == 23 && f23 != null)
+            {                
+                return f23(_value23);
+            }
+            if (_index == 24 && f24 != null)
+            {                
+                return f24(_value24);
+            }
+            if (_index == 25 && f25 != null)
+            {                
+                return f25(_value25);
+            }
+            if (_index == 26 && f26 != null)
+            {                
+                return f26(_value26);
+            }
+            if (_index == 27 && f27 != null)
+            {                
+                return f27(_value27);
+            }
+            if (_index == 28 && f28 != null)
+            {                
+                return f28(_value28);
+            }
+            if (_index == 29 && f29 != null)
+            {                
+                return f29(_value29);
+            }
+            if (_index == 30 && f30 != null)
+            {                
+                return f30(_value30);
+            }
+            if (_index == 31 && f31 != null)
+            {                
+                return f31(_value31);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9, Func<T10, TResult> f10, Func<T11, TResult> f11, Func<T12, TResult> f12, Func<T13, TResult> f13, Func<T14, TResult> f14, Func<T15, TResult> f15, Func<T16, TResult> f16, Func<T17, TResult> f17, Func<T18, TResult> f18, Func<T19, TResult> f19, Func<T20, TResult> f20, Func<T21, TResult> f21, Func<T22, TResult> f22, Func<T23, TResult> f23, Func<T24, TResult> f24, Func<T25, TResult> f25, Func<T26, TResult> f26, Func<T27, TResult> f27, Func<T28, TResult> f28, Func<T29, TResult> f29, Func<T30, TResult> f30, Func<T31, TResult> f31)
         {

--- a/OneOf.Extended/OneOfT9.generated.cs
+++ b/OneOf.Extended/OneOfT9.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -167,6 +171,53 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8, Func<T9, Task> f9)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            if (_index == 9 && f9 != null)
+            {                
+                return f9(_value9);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8, Func<T9, TResult> f9)
         {

--- a/OneOf.Tests/SwitchTests.cs
+++ b/OneOf.Tests/SwitchTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OneOf;
+
+namespace OneOf.Tests
+{
+    public class SwitchTests
+    {
+        private class SwitchAsyncException : Exception
+        {
+
+        }
+
+        [Test]
+        public async Task SwitchAsync()
+        {
+            OneOf<int, float> oneof = 10f;
+            string result = string.Empty;
+
+            await oneof.Switch(async f0 =>
+            {
+                result = await DoWorkAsync(f0);
+            }, async f1 =>
+            {
+                result = await DoWorkAsync(f1);
+            });
+
+            Assert.AreEqual("10.00", result);
+
+            Assert.ThrowsAsync<SwitchAsyncException>(async () =>
+            {
+                await oneof.Switch(async f0 =>
+                {
+                    result = await DoWorkAsync(f0);
+                }, async f1 =>
+                {
+                    result = await DoWorkWithErrorAsync(f1);
+                });
+
+            });
+        }
+
+        private string ResolveString(OneOf<double, int, string> input)
+            => input
+                .MapT0(d => d.ToString(CultureInfo.InvariantCulture))
+                .MapT1(i => i.ToString(CultureInfo.InvariantCulture))
+                .Match(t1 => t1, t2 => t2, t3 => t3);
+
+        private Task<string> DoWorkAsync(int value)
+        {
+            return Task.FromResult(value.ToString());
+        }
+
+        private Task<string> DoWorkAsync(float value)
+        {
+            return Task.FromResult(value.ToString("N"));
+        }
+
+        private Task<string> DoWorkWithErrorAsync(float value)
+        {
+            throw new SwitchAsyncException();
+        }
+    }
+}

--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -25,4 +25,22 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.Threading.Tasks">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Threading.Tasks">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/OneOf/OneOfBaseT0.generated.cs
+++ b/OneOf/OneOfBaseT0.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -45,6 +49,17 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {

--- a/OneOf/OneOfBaseT1.generated.cs
+++ b/OneOf/OneOfBaseT1.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -58,6 +62,21 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {

--- a/OneOf/OneOfBaseT2.generated.cs
+++ b/OneOf/OneOfBaseT2.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -71,6 +75,25 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {

--- a/OneOf/OneOfBaseT3.generated.cs
+++ b/OneOf/OneOfBaseT3.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -84,6 +88,29 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {

--- a/OneOf/OneOfBaseT4.generated.cs
+++ b/OneOf/OneOfBaseT4.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -97,6 +101,33 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {

--- a/OneOf/OneOfBaseT5.generated.cs
+++ b/OneOf/OneOfBaseT5.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -110,6 +114,37 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {

--- a/OneOf/OneOfBaseT6.generated.cs
+++ b/OneOf/OneOfBaseT6.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -123,6 +127,41 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {

--- a/OneOf/OneOfBaseT7.generated.cs
+++ b/OneOf/OneOfBaseT7.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -136,6 +140,45 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {

--- a/OneOf/OneOfBaseT8.generated.cs
+++ b/OneOf/OneOfBaseT8.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -149,6 +153,49 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {

--- a/OneOf/OneOfT0.generated.cs
+++ b/OneOf/OneOfT0.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -41,6 +45,17 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0)
         {

--- a/OneOf/OneOfT1.generated.cs
+++ b/OneOf/OneOfT1.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -55,6 +59,21 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1)
         {

--- a/OneOf/OneOfT2.generated.cs
+++ b/OneOf/OneOfT2.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -69,6 +73,25 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2)
         {

--- a/OneOf/OneOfT3.generated.cs
+++ b/OneOf/OneOfT3.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -83,6 +87,29 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3)
         {

--- a/OneOf/OneOfT4.generated.cs
+++ b/OneOf/OneOfT4.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -97,6 +101,33 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4)
         {

--- a/OneOf/OneOfT5.generated.cs
+++ b/OneOf/OneOfT5.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -111,6 +115,37 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5)
         {

--- a/OneOf/OneOfT6.generated.cs
+++ b/OneOf/OneOfT6.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -125,6 +129,41 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6)
         {

--- a/OneOf/OneOfT7.generated.cs
+++ b/OneOf/OneOfT7.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -139,6 +143,45 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7)
         {

--- a/OneOf/OneOfT8.generated.cs
+++ b/OneOf/OneOfT8.generated.cs
@@ -1,4 +1,8 @@
 using System;
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
 using static OneOf.Functions;
 
 namespace OneOf
@@ -153,6 +157,49 @@ namespace OneOf
             }
             throw new InvalidOperationException();
         }
+
+#if !NET35
+        public Task Switch(Func<T0, Task> f0, Func<T1, Task> f1, Func<T2, Task> f2, Func<T3, Task> f3, Func<T4, Task> f4, Func<T5, Task> f5, Func<T6, Task> f6, Func<T7, Task> f7, Func<T8, Task> f8)
+        {
+            if (_index == 0 && f0 != null)
+            {                
+                return f0(_value0);
+            }
+            if (_index == 1 && f1 != null)
+            {                
+                return f1(_value1);
+            }
+            if (_index == 2 && f2 != null)
+            {                
+                return f2(_value2);
+            }
+            if (_index == 3 && f3 != null)
+            {                
+                return f3(_value3);
+            }
+            if (_index == 4 && f4 != null)
+            {                
+                return f4(_value4);
+            }
+            if (_index == 5 && f5 != null)
+            {                
+                return f5(_value5);
+            }
+            if (_index == 6 && f6 != null)
+            {                
+                return f6(_value6);
+            }
+            if (_index == 7 && f7 != null)
+            {                
+                return f7(_value7);
+            }
+            if (_index == 8 && f8 != null)
+            {                
+                return f8(_value8);
+            }
+            throw new InvalidOperationException();
+        }
+#endif
 
         public TResult Match<TResult>(Func<T0, TResult> f0, Func<T1, TResult> f1, Func<T2, TResult> f2, Func<T3, TResult> f3, Func<T4, TResult> f4, Func<T5, TResult> f5, Func<T6, TResult> f6, Func<T7, TResult> f7, Func<T8, TResult> f8)
         {


### PR DESCRIPTION
Fixes #84.

I went with doing an overload of `Switch` instead of a separate `SwitchAsync` because I think it will provide a better default experience.  As soon as someone adds `async` to each of the actions, it will switch over to the `Func<>` overload instead of relying on someone to know to go look for an explicitly named Async version.