### PR TITLE
Simplify the generator's importation of `GenerateOneOfAttribute.g.cs` et al.

### DIFF
--- a/OneOf.Extended/OneOf.Extended.csproj
+++ b/OneOf.Extended/OneOf.Extended.csproj
@@ -9,7 +9,7 @@
     <Product>Harry McIntyre</Product>
     <Description>This package extends the OneOf types from OneOf&lt;T0, .., T9&gt; to OneOf&lt;T0, .., T32&gt; for when you really have a lot of options</Description>
     <PackageProjectUrl>https://github.com/mcintyre321/OneOf/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/mcintyre321/OneOf/blob/master/licence.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>discriminated unions, return type, match switch</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>OneOf.Extended</PackageId>

--- a/OneOf.FSharp/OneOf.FSharp.fsproj
+++ b/OneOf.FSharp/OneOf.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>OneOf.FSharp</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>

--- a/OneOf.FSharp/OneOf.FSharp.fsproj
+++ b/OneOf.FSharp/OneOf.FSharp.fsproj
@@ -11,7 +11,7 @@
     <Product>Harry McIntyre</Product>
     <Description>This is an FSharp library for interop with the C# OneOf Types</Description>
     <PackageProjectUrl>https://github.com/mcintyre321/OneOf/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/mcintyre321/OneOf/blob/master/licence.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>discriminated unions, return type, match switch</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>OneOf.FSharp</PackageId>

--- a/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
+++ b/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
@@ -9,7 +9,7 @@
     <Product>Harry McIntyre</Product>
     <Description>This source generator automaticly implements OneOfBase hierarchies</Description>
     <PackageProjectUrl>https://github.com/mcintyre321/OneOf/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/mcintyre321/OneOf/blob/master/licence.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>discriminated unions, return type, match switch, generator, source generator</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>OneOf.SourceGenerator</PackageId>


### PR DESCRIPTION
Instead of creating a new `Compilation` to add `GenerateOneOfAttribute.g.cs`, we now add it inside `GeneratorInitializationContext.RegisterForPostInitialization`, which is designed for such scenarios.

I also fixed some project file properties.