### PR TITLE
bumped source generator test to .NET 6

### DIFF
--- a/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
+++ b/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
+++ b/OneOf.SourceGenerator.Tests/OneOf.SourceGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
for some reason .NET 5 was not present in last appveyor build, I've bumped tests to .net 6, @mcintyre321 