### PR TITLE
Make OneOf structs readonly

### DIFF
--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -36,13 +36,13 @@ string GetContent(bool isStruct, int i) {
     var genericArgs = Range(0, i).Select(e => $"T{e}").ToList();
     var genericArg = genericArgs.Joined(", ");
     var sb = new StringBuilder();
-
+    
     sb.Append(@$"using System;
 using static OneOf.Functions;
 
 namespace OneOf
 {{
-    public {IfStruct("struct", "class")} {className}<{genericArg}> : IOneOf
+    public {IfStruct("readonly struct", "class")} {className}<{genericArg}> : IOneOf
     {{
         {RangeJoined(@"
         ", j => $"readonly T{j} _value{j};")}

--- a/OneOf.Extended/OneOfT10.generated.cs
+++ b/OneOf.Extended/OneOfT10.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT11.generated.cs
+++ b/OneOf.Extended/OneOfT11.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT12.generated.cs
+++ b/OneOf.Extended/OneOfT12.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT13.generated.cs
+++ b/OneOf.Extended/OneOfT13.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT14.generated.cs
+++ b/OneOf.Extended/OneOfT14.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT15.generated.cs
+++ b/OneOf.Extended/OneOfT15.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT16.generated.cs
+++ b/OneOf.Extended/OneOfT16.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT17.generated.cs
+++ b/OneOf.Extended/OneOfT17.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT18.generated.cs
+++ b/OneOf.Extended/OneOfT18.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT19.generated.cs
+++ b/OneOf.Extended/OneOfT19.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT20.generated.cs
+++ b/OneOf.Extended/OneOfT20.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT21.generated.cs
+++ b/OneOf.Extended/OneOfT21.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT22.generated.cs
+++ b/OneOf.Extended/OneOfT22.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT23.generated.cs
+++ b/OneOf.Extended/OneOfT23.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT24.generated.cs
+++ b/OneOf.Extended/OneOfT24.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT25.generated.cs
+++ b/OneOf.Extended/OneOfT25.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT26.generated.cs
+++ b/OneOf.Extended/OneOfT26.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT27.generated.cs
+++ b/OneOf.Extended/OneOfT27.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT28.generated.cs
+++ b/OneOf.Extended/OneOfT28.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT29.generated.cs
+++ b/OneOf.Extended/OneOfT29.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT30.generated.cs
+++ b/OneOf.Extended/OneOfT30.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT31.generated.cs
+++ b/OneOf.Extended/OneOfT31.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf.Extended/OneOfT9.generated.cs
+++ b/OneOf.Extended/OneOfT9.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT0.generated.cs
+++ b/OneOf/OneOfT0.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0> : IOneOf
+    public readonly struct OneOf<T0> : IOneOf
     {
         readonly T0 _value0;
         readonly int _index;

--- a/OneOf/OneOfT1.generated.cs
+++ b/OneOf/OneOfT1.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1> : IOneOf
+    public readonly struct OneOf<T0, T1> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT2.generated.cs
+++ b/OneOf/OneOfT2.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2> : IOneOf
+    public readonly struct OneOf<T0, T1, T2> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT3.generated.cs
+++ b/OneOf/OneOfT3.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT4.generated.cs
+++ b/OneOf/OneOfT4.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT5.generated.cs
+++ b/OneOf/OneOfT5.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT6.generated.cs
+++ b/OneOf/OneOfT6.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT7.generated.cs
+++ b/OneOf/OneOfT7.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;

--- a/OneOf/OneOfT8.generated.cs
+++ b/OneOf/OneOfT8.generated.cs
@@ -3,7 +3,7 @@ using static OneOf.Functions;
 
 namespace OneOf
 {
-    public struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
+    public readonly struct OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IOneOf
     {
         readonly T0 _value0;
         readonly T1 _value1;


### PR DESCRIPTION
Solves #120, improving performance when passing a `struct` to a method using the `in` keyword. 

[MS Docs](https://learn.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#declare-immutable-structs-as-readonly)
[Blogpost with more insight](https://devblogs.microsoft.com/premier-developer/avoiding-struct-and-readonly-reference-performance-pitfalls-with-errorprone-net/)
[Stack overflow discussion](https://stackoverflow.com/questions/50539764/dodging-the-performance-hit-from-using-in-with-a-struct-without-making-the-str)

#### TL;DR
Using `in` for a parameter lets us pass by reference, but then prevents us from assigning a value to it. However the performance can actually become worse, because it creates a "defensive copy" of the `struct`, copying the whole thing. A way around this is to use read-only for a `struct`. When you pass it into an `in` parameter, the compiler sees that it's read-only and won't create the defensive copy, thereby making it the better alternative for performance.