### PR TITLE
Created project OneOf.Serialization

### DIFF
--- a/OneOf.Serialization/OneOf.Serialization.csproj
+++ b/OneOf.Serialization/OneOf.Serialization.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+    <LangVersion>11.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="OneOf" Version="3.0.223" />
+    <PackageReference Include="OneOf.SourceGenerator" Version="3.0.223" />
+  </ItemGroup>
+</Project>

--- a/OneOf.Serialization/OneOfJsonConverter.cs
+++ b/OneOf.Serialization/OneOfJsonConverter.cs
@@ -1,0 +1,137 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace OneOf.Serialization;
+
+public class OneOfJsonConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+        => typeof(IOneOf).IsAssignableFrom(objectType);
+
+    public override void WriteJson(
+        JsonWriter writer,
+        object value,
+        JsonSerializer serializer
+    )
+    {
+        var (oneOfGenericType, oneOfJsonGenericType) =
+            GetTypes(value.GetType());
+        if (oneOfGenericType is null)
+            return;
+        var oneOfJsonType = oneOfJsonGenericType
+            .MakeGenericType(oneOfGenericType.GenericTypeArguments);
+        var oneOfJson = Activator.CreateInstance(oneOfJsonType);
+        var oneOfJsonIndex = ((dynamic)value).Index;
+        var oneOfJsonValue = ((dynamic)value).Value;
+        ((dynamic)oneOfJson).Index = oneOfJsonIndex;
+        if (oneOfJsonIndex == 0)
+            ((dynamic)oneOfJson).Value0 = oneOfJsonValue;
+        if (oneOfJsonIndex == 1)
+            ((dynamic)oneOfJson).Value1 = oneOfJsonValue;
+        if (oneOfJsonIndex == 2)
+            ((dynamic)oneOfJson).Value2 = oneOfJsonValue;
+        if (oneOfJsonIndex == 3)
+            ((dynamic)oneOfJson).Value3 = oneOfJsonValue;
+        if (oneOfJsonIndex == 4)
+            ((dynamic)oneOfJson).Value4 = oneOfJsonValue;
+        if (oneOfJsonIndex == 5)
+            ((dynamic)oneOfJson).Value5 = oneOfJsonValue;
+        if (oneOfJsonIndex == 6)
+            ((dynamic)oneOfJson).Value6 = oneOfJsonValue;
+        if (oneOfJsonIndex == 7)
+            ((dynamic)oneOfJson).Value7 = oneOfJsonValue;
+        if (oneOfJsonIndex == 7)
+            ((dynamic)oneOfJson).Value7 = oneOfJsonValue;
+        if (oneOfJsonIndex == 8)
+            ((dynamic)oneOfJson).Value8 = oneOfJsonValue;
+        serializer.Serialize(writer, oneOfJson);
+    }
+
+    public override object ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object existingValue,
+        JsonSerializer serializer
+    )
+    {
+        var (oneOfGenericType, oneOfJsonGenericType) =
+            GetTypes(objectType);
+        if (oneOfGenericType is null)
+            return null;
+
+        var children = JObject.Load(reader).Children();
+        var index = children.ElementAt(0).First.Value<int>();
+        var type = oneOfGenericType.GenericTypeArguments[index];
+        var value = children.ElementAt(index + 1).First.ToObject(type);
+
+        if (false == _cache.TryGetValue((objectType, type), out var method))
+        {
+            method = objectType
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .FirstOrDefault(x =>
+                {
+                    if (x.IsSpecialName == false)
+                        return false;
+                    if (x.Name != "op_Implicit" &&
+                        x.Name != "op_Explicit")
+                        return false;
+                    var parameters = x.GetParameters();
+                    if (parameters.Length != 1)
+                        return false;
+                    var parameter = parameters[0];
+                    if (parameter.ParameterType != type)
+                        return false;
+                    return true;
+                });
+            if (method is null)
+                throw new Exception("No compatible method was found.");
+            _cache.TryAdd((objectType, type), method);
+        }
+
+        var result = method.Invoke(null, new object[] { value });
+        return result;
+    }
+
+    private static readonly ConcurrentDictionary<(Type, Type), MethodInfo> _cache = new();
+
+    private static (Type oneOfGenericType, Type oneOfJsonGenericType) GetTypes(Type type)
+    {
+        while (type is not null)
+        {
+            if (type.IsGenericType)
+            {
+                var genericTypeDefinition = type.GetGenericTypeDefinition();
+                if (genericTypeDefinition == typeof(OneOfBase<,>) ||
+                    genericTypeDefinition == typeof(OneOf<,>))
+                    return (type, typeof(OneOfJson<,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,>))
+                    return (type, typeof(OneOfJson<,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,>))
+                    return (type, typeof(OneOfJson<,,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,,>))
+                    return (type, typeof(OneOfJson<,,,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,,,>))
+                    return (type, typeof(OneOfJson<,,,,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,,,,>))
+                    return (type, typeof(OneOfJson<,,,,,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,,,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,,,,,>))
+                    return (type, typeof(OneOfJson<,,,,,,,>));
+                if (genericTypeDefinition == typeof(OneOfBase<,,,,,,,,>) ||
+                    genericTypeDefinition == typeof(OneOf<,,,,,,,,>))
+                    return (type, typeof(OneOfJson<,,,,,,,,>));
+            }
+            type = type.BaseType;
+        }
+        return (null, null);
+    }
+}

--- a/OneOf.Serialization/OneOfJsons.cs
+++ b/OneOf.Serialization/OneOfJsons.cs
@@ -1,0 +1,78 @@
+﻿namespace OneOf.Serialization;
+
+public struct OneOfJson<T0, T1>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+}
+public struct OneOfJson<T0, T1, T2>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+}
+public struct OneOfJson<T0, T1, T2, T3>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+}
+public struct OneOfJson<T0, T1, T2, T3, T4>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+    public T4 Value4;
+}
+public struct OneOfJson<T0, T1, T2, T3, T4, T5>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+    public T4 Value4;
+    public T5 Value5;
+}
+public struct OneOfJson<T0, T1, T2, T3, T4, T5, T6>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+    public T4 Value4;
+    public T5 Value5;
+    public T6 Value6;
+}
+public struct OneOfJson<T0, T1, T2, T3, T4, T5, T6, T7>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+    public T4 Value4;
+    public T5 Value5;
+    public T6 Value6;
+    public T7 Value7;
+}
+public struct OneOfJson<T0, T1, T2, T3, T4, T5, T6, T7, T8>
+{
+    public int Index;
+    public T0 Value0;
+    public T1 Value1;
+    public T2 Value2;
+    public T3 Value3;
+    public T4 Value4;
+    public T5 Value5;
+    public T6 Value6;
+    public T7 Value7;
+    public T8 Value8;
+}

--- a/OneOf.SerializationTests/OneOf.SerializationTests.csproj
+++ b/OneOf.SerializationTests/OneOf.SerializationTests.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+    <LangVersion>11.0</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" TreatAsUsed="true" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OneOf.Serialization\OneOf.Serialization.csproj" />
+  </ItemGroup>
+</Project>

--- a/OneOf.SerializationTests/OneOfJsonConverterTests.cs
+++ b/OneOf.SerializationTests/OneOfJsonConverterTests.cs
@@ -1,0 +1,378 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace OneOf.Serialization.Tests;
+
+[TestFixture()]
+public class OneOfJsonConverterTests
+{
+    [Test()]
+    public void OneOf_Test()
+    {
+        var oneOf = new OneOf<bool, char, int, decimal, string, Parent, Child[]>();
+        var serialized = "";
+        var deserialized = default(OneOf<bool, char, int, decimal, string, Parent, Child[]>);
+
+        // bool
+        oneOf = true;
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 0,
+              "Value0": true,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // char
+        oneOf = 'A';
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 1,
+              "Value0": false,
+              "Value1": "A",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // int
+        oneOf = 123;
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 2,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 123,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // decimal
+        oneOf = 123.45m;
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 3,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 123.45,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // decimal
+        oneOf = "lorem ipsum";
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 4,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": "lorem ipsum",
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // Parent
+        oneOf = new Parent()
+        {
+            foo = "Foo",
+            bar = "Bar",
+            child = new Child()
+            {
+                qux = "Qux",
+            },
+        };
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 5,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": {
+                "foo": "Foo",
+                "bar": "Bar",
+                "child": {
+                  "qux": "Qux"
+                }
+              },
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+
+        // Child[]
+        oneOf = new[]
+        {
+            new Child() { qux = "qux" },
+            new Child() { qux = "QUX" },
+        };
+        serialized = JsonConvert.SerializeObject(
+            oneOf, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 6,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": [
+                {
+                  "qux": "qux"
+                },
+                {
+                  "qux": "QUX"
+                }
+              ]
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject
+            <OneOf<bool, char, int, decimal, string, Parent, Child[]>>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOf.Value, deserialized.Value);
+    }
+
+    [Test()]
+    public void OneOfBase_Test()
+    {
+        var oneOfBase = default(MockOneOfBase);
+        var serialized = "";
+        var deserialized = default(MockOneOfBase);
+
+        // bool
+        oneOfBase = true;
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 0,
+              "Value0": true,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // char
+        oneOfBase = 'A';
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 1,
+              "Value0": false,
+              "Value1": "A",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // int
+        oneOfBase = 123;
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 2,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 123,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // decimal
+        oneOfBase = 123.45m;
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 3,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 123.45,
+              "Value4": null,
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // decimal
+        oneOfBase = "lorem ipsum";
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 4,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": "lorem ipsum",
+              "Value5": null,
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // Parent
+        oneOfBase = new Parent()
+        {
+            foo = "Foo",
+            bar = "Bar",
+            child = new Child()
+            {
+                qux = "Qux",
+            },
+        };
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 5,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": {
+                "foo": "Foo",
+                "bar": "Bar",
+                "child": {
+                  "qux": "Qux"
+                }
+              },
+              "Value6": null
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+
+        // Child[]
+        oneOfBase = new[]
+        {
+            new Child() { qux = "qux" },
+            new Child() { qux = "QUX" },
+        };
+        serialized = JsonConvert.SerializeObject(
+            oneOfBase, Formatting.Indented, new OneOfJsonConverter());
+        Assert.AreEqual("""
+            {
+              "Index": 6,
+              "Value0": false,
+              "Value1": "\u0000",
+              "Value2": 0,
+              "Value3": 0.0,
+              "Value4": null,
+              "Value5": null,
+              "Value6": [
+                {
+                  "qux": "qux"
+                },
+                {
+                  "qux": "QUX"
+                }
+              ]
+            }
+            """, serialized);
+        deserialized = JsonConvert.DeserializeObject<MockOneOfBase>(
+            serialized, new OneOfJsonConverter());
+        Assert.AreEqual(oneOfBase.Value, deserialized.Value);
+    }
+}
+
+[GenerateOneOf()]
+public partial class MockOneOfBase
+    : OneOfBase<bool, char, int, decimal, string, Parent, Child[]>
+{
+}
+
+public record Parent
+{
+    public string foo;
+    public string bar;
+    public Child child;
+}
+public record Child
+{
+    public string qux;
+}

--- a/OneOf.sln
+++ b/OneOf.sln
@@ -20,7 +20,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator", "On
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator.Tests", "OneOf.SourceGenerator.Tests\OneOf.SourceGenerator.Tests.csproj", "{A7D18F0E-8966-4685-8146-34F507356F5D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneOf.SourceGenerator.AnalyzerTests", "OneOf.SourceGenerator.AnalyzerTests\OneOf.SourceGenerator.AnalyzerTests.csproj", "{C08F270E-157A-48B9-A7B6-C948FCFC5494}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator.AnalyzerTests", "OneOf.SourceGenerator.AnalyzerTests\OneOf.SourceGenerator.AnalyzerTests.csproj", "{C08F270E-157A-48B9-A7B6-C948FCFC5494}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.Serialization", "OneOf.Serialization\OneOf.Serialization.csproj", "{0C23EEC4-CAB2-4C6A-8F33-498F0C692696}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneOf.SerializationTests", "OneOf.SerializationTests\OneOf.SerializationTests.csproj", "{54A52714-2DAD-45B0-A8FB-BCDBA849B4F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +64,14 @@ Global
 		{C08F270E-157A-48B9-A7B6-C948FCFC5494}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C08F270E-157A-48B9-A7B6-C948FCFC5494}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C08F270E-157A-48B9-A7B6-C948FCFC5494}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C23EEC4-CAB2-4C6A-8F33-498F0C692696}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C23EEC4-CAB2-4C6A-8F33-498F0C692696}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C23EEC4-CAB2-4C6A-8F33-498F0C692696}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C23EEC4-CAB2-4C6A-8F33-498F0C692696}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54A52714-2DAD-45B0-A8FB-BCDBA849B4F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54A52714-2DAD-45B0-A8FB-BCDBA849B4F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54A52714-2DAD-45B0-A8FB-BCDBA849B4F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54A52714-2DAD-45B0-A8FB-BCDBA849B4F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The `OneOfJsonConverter` class can **serialize and DESERIALIZE** any `OneOf<>` or `OneOfBase<>` types, from `T0,T1` to `T0,T1,T2,T3,T4,T5,T6,T7,T8`.

Unit tests and examples can be found in the `OneOf.SerializationTests` project.

If necessary, another project (`OneOf.Extended.Serialization` or `OneOf.Serialization.Extended`) could handle the `OneOf.Extended` types.