### PR TITLE
Add doc comments and equality implementations, minor tweaks

### DIFF
--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -8,7 +8,8 @@ using System.Collections.Generic;
 
 var sourceRoot = GetFullPath(Combine(GetDirectoryName(GetExecutingAssembly().Location)!, @"..\..\..\.."));
 
-for (var i = 1; i < 10; i++) {
+for(var i = 1; i < 10; i++)
+{
     var output = GetContent(true, i);
     var outpath = Combine(sourceRoot, $"OneOf\\OneOfT{i - 1}.generated.cs");
     File.WriteAllText(outpath, output);
@@ -18,7 +19,8 @@ for (var i = 1; i < 10; i++) {
     File.WriteAllText(outpath2, output2);
 }
 
-for (var i = 10; i < 33; i++) {
+for(var i = 10; i < 33; i++)
+{
     var output3 = GetContent(true, i);
     var outpath3 = Combine(sourceRoot, $"OneOf.Extended\\OneOfT{i - 1}.generated.cs");
     File.WriteAllText(outpath3, output3);
@@ -28,7 +30,8 @@ for (var i = 10; i < 33; i++) {
     File.WriteAllText(outpath4, output4);
 }
 
-string GetContent(bool isStruct, int i) {
+string GetContent(bool isStruct, int i)
+{
     string RangeJoined(string delimiter, Func<int, string> selector) => Range(0, i).Joined(delimiter, selector);
     string IfStruct(string s, string s2 = "") => isStruct ? s : s2;
     string OrdinalOf(int cardinal) => (cardinal + 1) switch
@@ -207,10 +210,11 @@ t => $@"/// <summary>
         /// Creates an instance of this union representing the value provided.
         /// </summary>
         /// <param name=""value"">The value to wrap inside a discriminated union instance.</param>
+        /// <returns>A union representing the value provided.</returns>
         public static OneOf<{genericArgs.Joined(", ")}> From{t}({t} value) => value;"))}
 
         {IfStruct(genericArgs.Joined(@"
-            ", bindToType =>
+            ", (bindToType, j) =>
 {
     var resultArgsPrinted = genericArgs
         .Select(x => x == bindToType ? "TResult" : x)
@@ -219,13 +223,20 @@ t => $@"/// <summary>
     return $@"
         /// <summary>
         /// Maps this instance onto another union type of the same arity, 
-        /// with its <typeparamref name=""{bindToType}""/> mapped to <typeparamref name=""TResult""/>.
+        /// with its {OrdinalOf(j)} type (<typeparamref name=""{bindToType}""/>) 
+        /// mapped to <typeparamref name=""TResult""/>. If the union is representing
+        /// a corresponding value, it will be mapped using the projection provided.
         /// </summary>
         /// <param name=""mapFunc"">
         /// The delegate used to map this unions value onto <typeparamref name=""TResult""/>,
         /// if this union is representing it.
         /// </param>
         /// <typeparam name=""TResult"">The type to map <typeparamref name=""{bindToType}""/> onto.</typeparam>
+        /// <returns>
+        /// A new union instance of the same arity, representing the same value, 
+        /// but with the {OrdinalOf(j)} type (<typeparamref name=""{bindToType}""/>) 
+        /// mapped onto <typeparamref name=""TResult""/>.
+        /// </returns>
         public OneOf<{resultArgsPrinted}> Map{bindToType}<TResult>(Func<{bindToType}, TResult> mapFunc)
         {{
             if (mapFunc == null)

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -183,7 +183,7 @@ $"\t\t/// <param name=\"f{j}\">The delegate to execute if this union represents 
 {RangeJoined(@"
 ", j =>
 $"\t\t/// <param name=\"f{j}\">The projection to execute if this union represents a value of type <typeparamref name=\"T{j}\"/>.</param>")}
-        /// <returns></returns>
+        /// <returns>The projected value.</returns>
         public TResult Match<TResult>({RangeJoined(", ", j => $"Func<T{j}, TResult> f{j}")})
         {{
             switch(_index)

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -161,7 +161,7 @@ $"\t\t/// <param name=\"f{j}\">The delegate to execute if this union represents 
 {RangeJoined(@"
 ", j =>
 $"\t\t/// <param name=\"f{j}\">The projection to execute if this union represents a value of type <typeparamref name=\"T{j}\"/>.</param>")}
-        /// <returns></returns>
+        /// <returns>The projected value.</returns>
         public TResult Match<TResult>({RangeJoined(", ", e => $"Func<T{e}, TResult> f{e}")})
         {{
             {RangeJoined(@"
@@ -176,7 +176,9 @@ $"\t\t/// <param name=\"f{j}\">The projection to execute if this union represent
         ", bindToType => $@"/// <summary>
         /// Creates an instance of this union representing the value provided.
         /// </summary>
-        /// <param name=""value"">The value to wrap inside a discriminated union instance.</param>public static OneOf<{genericArgs.Joined(", ")}> From{bindToType}({bindToType} input) => input;"))}
+        /// <param name=""input"">The value to wrap inside a discriminated union instance.</param>
+        /// <returns>A new union wrapping the value provided.</returns>
+        public static OneOf<{genericArgs.Joined(", ")}> From{bindToType}({bindToType} input) => input;"))}
 
         {IfStruct(genericArgs.Joined(@"
             ", bindToType =>

--- a/OneOf.Tests/ToStringTests.cs
+++ b/OneOf.Tests/ToStringTests.cs
@@ -21,7 +21,7 @@ namespace OneOf.Tests
             }
         }
 
-        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 am")]
         [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
         public string LeftSideFormatsWithCurrentCulture(string cultureName)
         {
@@ -32,7 +32,7 @@ namespace OneOf.Tests
             });
         }
 
-        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 AM")]
+        [TestCase("en-NZ", ExpectedResult = "System.DateTime: 2/01/2019 1:02:03 am")]
         [TestCase("en-US", ExpectedResult = "System.DateTime: 1/2/2019 1:02:03 AM")]
         public string RightSideFormatsWithCurrentCulture(string cultureName)
         {


### PR DESCRIPTION
I have extended the generator program to emit the following features:

- expansive and descriptive doc comments for better API legibility
- the OneOf struct implements IEquatable<> to obviate undesired boxing
- the OneOf struct implements the == and != operators to improve comparison semantics
- various function implementations have been changed to use switch 
- a unified exception message for invalid index values has been introduced

In addition, I have modified two tests that were expecting incorrect (according to the framework and [Wikipedia](wikipedia.org/wiki/Date_and_time_notation_in_New_Zealand#Time)) DateTime strings.