### PR TITLE
add new method WithType to add types to a OneOf

### DIFF
--- a/OneOf.Extended/OneOfBaseT10.generated.cs
+++ b/OneOf.Extended/OneOfBaseT10.generated.cs
@@ -18,7 +18,7 @@ namespace OneOf
         readonly T10 _value10;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> input)
         {
             _index = input.Index;
             switch (_index)
@@ -56,6 +56,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT11.generated.cs
+++ b/OneOf.Extended/OneOfBaseT11.generated.cs
@@ -19,7 +19,7 @@ namespace OneOf
         readonly T11 _value11;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> input)
         {
             _index = input.Index;
             switch (_index)
@@ -59,6 +59,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT12.generated.cs
+++ b/OneOf.Extended/OneOfBaseT12.generated.cs
@@ -20,7 +20,7 @@ namespace OneOf
         readonly T12 _value12;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> input)
         {
             _index = input.Index;
             switch (_index)
@@ -62,6 +62,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT13.generated.cs
+++ b/OneOf.Extended/OneOfBaseT13.generated.cs
@@ -21,7 +21,7 @@ namespace OneOf
         readonly T13 _value13;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> input)
         {
             _index = input.Index;
             switch (_index)
@@ -65,6 +65,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT14.generated.cs
+++ b/OneOf.Extended/OneOfBaseT14.generated.cs
@@ -22,7 +22,7 @@ namespace OneOf
         readonly T14 _value14;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> input)
         {
             _index = input.Index;
             switch (_index)
@@ -68,6 +68,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT15.generated.cs
+++ b/OneOf.Extended/OneOfBaseT15.generated.cs
@@ -23,7 +23,7 @@ namespace OneOf
         readonly T15 _value15;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> input)
         {
             _index = input.Index;
             switch (_index)
@@ -71,6 +71,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT16.generated.cs
+++ b/OneOf.Extended/OneOfBaseT16.generated.cs
@@ -24,7 +24,7 @@ namespace OneOf
         readonly T16 _value16;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> input)
         {
             _index = input.Index;
             switch (_index)
@@ -74,6 +74,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT17.generated.cs
+++ b/OneOf.Extended/OneOfBaseT17.generated.cs
@@ -25,7 +25,7 @@ namespace OneOf
         readonly T17 _value17;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> input)
         {
             _index = input.Index;
             switch (_index)
@@ -77,6 +77,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT18.generated.cs
+++ b/OneOf.Extended/OneOfBaseT18.generated.cs
@@ -26,7 +26,7 @@ namespace OneOf
         readonly T18 _value18;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> input)
         {
             _index = input.Index;
             switch (_index)
@@ -80,6 +80,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT19.generated.cs
+++ b/OneOf.Extended/OneOfBaseT19.generated.cs
@@ -27,7 +27,7 @@ namespace OneOf
         readonly T19 _value19;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> input)
         {
             _index = input.Index;
             switch (_index)
@@ -83,6 +83,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT20.generated.cs
+++ b/OneOf.Extended/OneOfBaseT20.generated.cs
@@ -28,7 +28,7 @@ namespace OneOf
         readonly T20 _value20;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> input)
         {
             _index = input.Index;
             switch (_index)
@@ -86,6 +86,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT21.generated.cs
+++ b/OneOf.Extended/OneOfBaseT21.generated.cs
@@ -29,7 +29,7 @@ namespace OneOf
         readonly T21 _value21;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> input)
         {
             _index = input.Index;
             switch (_index)
@@ -89,6 +89,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT22.generated.cs
+++ b/OneOf.Extended/OneOfBaseT22.generated.cs
@@ -30,7 +30,7 @@ namespace OneOf
         readonly T22 _value22;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> input)
         {
             _index = input.Index;
             switch (_index)
@@ -92,6 +92,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT23.generated.cs
+++ b/OneOf.Extended/OneOfBaseT23.generated.cs
@@ -31,7 +31,7 @@ namespace OneOf
         readonly T23 _value23;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> input)
         {
             _index = input.Index;
             switch (_index)
@@ -95,6 +95,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT24.generated.cs
+++ b/OneOf.Extended/OneOfBaseT24.generated.cs
@@ -32,7 +32,7 @@ namespace OneOf
         readonly T24 _value24;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> input)
         {
             _index = input.Index;
             switch (_index)
@@ -98,6 +98,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT25.generated.cs
+++ b/OneOf.Extended/OneOfBaseT25.generated.cs
@@ -33,7 +33,7 @@ namespace OneOf
         readonly T25 _value25;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25> input)
         {
             _index = input.Index;
             switch (_index)
@@ -101,6 +101,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT26.generated.cs
+++ b/OneOf.Extended/OneOfBaseT26.generated.cs
@@ -34,7 +34,7 @@ namespace OneOf
         readonly T26 _value26;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26> input)
         {
             _index = input.Index;
             switch (_index)
@@ -104,6 +104,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT27.generated.cs
+++ b/OneOf.Extended/OneOfBaseT27.generated.cs
@@ -35,7 +35,7 @@ namespace OneOf
         readonly T27 _value27;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27> input)
         {
             _index = input.Index;
             switch (_index)
@@ -107,6 +107,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT28.generated.cs
+++ b/OneOf.Extended/OneOfBaseT28.generated.cs
@@ -36,7 +36,7 @@ namespace OneOf
         readonly T28 _value28;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28> input)
         {
             _index = input.Index;
             switch (_index)
@@ -110,6 +110,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT29.generated.cs
+++ b/OneOf.Extended/OneOfBaseT29.generated.cs
@@ -37,7 +37,7 @@ namespace OneOf
         readonly T29 _value29;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29> input)
         {
             _index = input.Index;
             switch (_index)
@@ -113,6 +113,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT30.generated.cs
+++ b/OneOf.Extended/OneOfBaseT30.generated.cs
@@ -38,7 +38,7 @@ namespace OneOf
         readonly T30 _value30;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30> input)
         {
             _index = input.Index;
             switch (_index)
@@ -116,6 +116,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT31.generated.cs
+++ b/OneOf.Extended/OneOfBaseT31.generated.cs
@@ -39,7 +39,7 @@ namespace OneOf
         readonly T31 _value31;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31> input)
         {
             _index = input.Index;
             switch (_index)
@@ -119,6 +119,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfBaseT9.generated.cs
+++ b/OneOf.Extended/OneOfBaseT9.generated.cs
@@ -17,7 +17,7 @@ namespace OneOf
         readonly T9 _value9;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> input)
         {
             _index = input.Index;
             switch (_index)
@@ -53,6 +53,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT10.generated.cs
+++ b/OneOf.Extended/OneOfT10.generated.cs
@@ -18,7 +18,7 @@ namespace OneOf
         readonly T10 _value10;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default)
         {
             _index = index;
             _value0 = value0;
@@ -52,6 +52,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT11.generated.cs
+++ b/OneOf.Extended/OneOfT11.generated.cs
@@ -19,7 +19,7 @@ namespace OneOf
         readonly T11 _value11;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default)
         {
             _index = index;
             _value0 = value0;
@@ -55,6 +55,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT12.generated.cs
+++ b/OneOf.Extended/OneOfT12.generated.cs
@@ -20,7 +20,7 @@ namespace OneOf
         readonly T12 _value12;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default)
         {
             _index = index;
             _value0 = value0;
@@ -58,6 +58,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT13.generated.cs
+++ b/OneOf.Extended/OneOfT13.generated.cs
@@ -21,7 +21,7 @@ namespace OneOf
         readonly T13 _value13;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default)
         {
             _index = index;
             _value0 = value0;
@@ -61,6 +61,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT14.generated.cs
+++ b/OneOf.Extended/OneOfT14.generated.cs
@@ -22,7 +22,7 @@ namespace OneOf
         readonly T14 _value14;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default)
         {
             _index = index;
             _value0 = value0;
@@ -64,6 +64,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT15.generated.cs
+++ b/OneOf.Extended/OneOfT15.generated.cs
@@ -23,7 +23,7 @@ namespace OneOf
         readonly T15 _value15;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default)
         {
             _index = index;
             _value0 = value0;
@@ -67,6 +67,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT16.generated.cs
+++ b/OneOf.Extended/OneOfT16.generated.cs
@@ -24,7 +24,7 @@ namespace OneOf
         readonly T16 _value16;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default)
         {
             _index = index;
             _value0 = value0;
@@ -70,6 +70,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT17.generated.cs
+++ b/OneOf.Extended/OneOfT17.generated.cs
@@ -25,7 +25,7 @@ namespace OneOf
         readonly T17 _value17;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default)
         {
             _index = index;
             _value0 = value0;
@@ -73,6 +73,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT18.generated.cs
+++ b/OneOf.Extended/OneOfT18.generated.cs
@@ -26,7 +26,7 @@ namespace OneOf
         readonly T18 _value18;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default)
         {
             _index = index;
             _value0 = value0;
@@ -76,6 +76,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT19.generated.cs
+++ b/OneOf.Extended/OneOfT19.generated.cs
@@ -27,7 +27,7 @@ namespace OneOf
         readonly T19 _value19;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default)
         {
             _index = index;
             _value0 = value0;
@@ -79,6 +79,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT20.generated.cs
+++ b/OneOf.Extended/OneOfT20.generated.cs
@@ -28,7 +28,7 @@ namespace OneOf
         readonly T20 _value20;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default)
         {
             _index = index;
             _value0 = value0;
@@ -82,6 +82,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT21.generated.cs
+++ b/OneOf.Extended/OneOfT21.generated.cs
@@ -29,7 +29,7 @@ namespace OneOf
         readonly T21 _value21;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default)
         {
             _index = index;
             _value0 = value0;
@@ -85,6 +85,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT22.generated.cs
+++ b/OneOf.Extended/OneOfT22.generated.cs
@@ -30,7 +30,7 @@ namespace OneOf
         readonly T22 _value22;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default)
         {
             _index = index;
             _value0 = value0;
@@ -88,6 +88,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT23.generated.cs
+++ b/OneOf.Extended/OneOfT23.generated.cs
@@ -31,7 +31,7 @@ namespace OneOf
         readonly T23 _value23;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default)
         {
             _index = index;
             _value0 = value0;
@@ -91,6 +91,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT24.generated.cs
+++ b/OneOf.Extended/OneOfT24.generated.cs
@@ -32,7 +32,7 @@ namespace OneOf
         readonly T24 _value24;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default)
         {
             _index = index;
             _value0 = value0;
@@ -94,6 +94,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT25.generated.cs
+++ b/OneOf.Extended/OneOfT25.generated.cs
@@ -33,7 +33,7 @@ namespace OneOf
         readonly T25 _value25;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default)
         {
             _index = index;
             _value0 = value0;
@@ -97,6 +97,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT26.generated.cs
+++ b/OneOf.Extended/OneOfT26.generated.cs
@@ -34,7 +34,7 @@ namespace OneOf
         readonly T26 _value26;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default)
         {
             _index = index;
             _value0 = value0;
@@ -100,6 +100,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT27.generated.cs
+++ b/OneOf.Extended/OneOfT27.generated.cs
@@ -35,7 +35,7 @@ namespace OneOf
         readonly T27 _value27;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default)
         {
             _index = index;
             _value0 = value0;
@@ -103,6 +103,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT28.generated.cs
+++ b/OneOf.Extended/OneOfT28.generated.cs
@@ -36,7 +36,7 @@ namespace OneOf
         readonly T28 _value28;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default)
         {
             _index = index;
             _value0 = value0;
@@ -106,6 +106,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT29.generated.cs
+++ b/OneOf.Extended/OneOfT29.generated.cs
@@ -37,7 +37,7 @@ namespace OneOf
         readonly T29 _value29;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default)
         {
             _index = index;
             _value0 = value0;
@@ -109,6 +109,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT30.generated.cs
+++ b/OneOf.Extended/OneOfT30.generated.cs
@@ -38,7 +38,7 @@ namespace OneOf
         readonly T30 _value30;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default)
         {
             _index = index;
             _value0 = value0;
@@ -112,6 +112,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT31.generated.cs
+++ b/OneOf.Extended/OneOfT31.generated.cs
@@ -39,7 +39,7 @@ namespace OneOf
         readonly T31 _value31;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default, T31 value31 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default, T10 value10 = default, T11 value11 = default, T12 value12 = default, T13 value13 = default, T14 value14 = default, T15 value15 = default, T16 value16 = default, T17 value17 = default, T18 value18 = default, T19 value19 = default, T20 value20 = default, T21 value21 = default, T22 value22 = default, T23 value23 = default, T24 value24 = default, T25 value25 = default, T26 value26 = default, T27 value27 = default, T28 value28 = default, T29 value29 = default, T30 value30 = default, T31 value31 = default)
         {
             _index = index;
             _value0 = value0;
@@ -115,6 +115,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Extended/OneOfT9.generated.cs
+++ b/OneOf.Extended/OneOfT9.generated.cs
@@ -17,7 +17,7 @@ namespace OneOf
         readonly T9 _value9;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default, T9 value9 = default)
         {
             _index = index;
             _value0 = value0;
@@ -49,6 +49,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf.Tests/WithTypeTests.cs
+++ b/OneOf.Tests/WithTypeTests.cs
@@ -1,0 +1,51 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OneOf.Tests {
+    public class WithTypeTests {
+        [Test]
+        public void WithType() {
+            var example = OneOf<int, long, double, char>.FromT2(5.0);
+            var result = example.WithType<string>();
+            Assert.AreEqual(result.Value, 5.0); 
+            Assert.AreEqual(result.Value, example.Value);
+            Assert.AreEqual(result.Index, example.Index);
+            Assert.IsTrue(result.IsT2);
+            Assert.IsFalse(result.IsT4);
+        }
+
+        #region the example code from the readme
+        public OneOf<string, double> ParseDouble(string input) {
+            if (double.TryParse(input, out var result)) {
+                return result;
+            } else {
+                return input;
+            }
+        }
+
+        public OneOf<string, double, DateTime, int> ParseDoubleOrUTCDateOrInt(string input) {
+            if (DateTime.TryParseExact(input, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dateResult)) {
+                return dateResult;
+            }
+            else if (int.TryParse(input, out var intResult)) {
+                return intResult;
+            } else {
+                return ParseDouble(input).WithType<DateTime>().WithType<int>();
+            }
+        }
+
+        [Test]
+        public void TestParseDoubleOrUTCDateOrInt() {
+            Assert.AreEqual(ParseDoubleOrUTCDateOrInt("fred").AsT0, "fred");
+            Assert.AreEqual(ParseDoubleOrUTCDateOrInt("5.5").AsT1, 5.5);
+            Assert.AreEqual(ParseDoubleOrUTCDateOrInt("2000-01-01").AsT2, new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Unspecified));
+            Assert.AreEqual(ParseDoubleOrUTCDateOrInt("999").AsT3, 999);
+        }
+        #endregion
+    }
+}

--- a/OneOf.sln
+++ b/OneOf.sln
@@ -20,7 +20,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator", "On
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator.Tests", "OneOf.SourceGenerator.Tests\OneOf.SourceGenerator.Tests.csproj", "{A7D18F0E-8966-4685-8146-34F507356F5D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OneOf.SourceGenerator.AnalyzerTests", "OneOf.SourceGenerator.AnalyzerTests\OneOf.SourceGenerator.AnalyzerTests.csproj", "{C08F270E-157A-48B9-A7B6-C948FCFC5494}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OneOf.SourceGenerator.AnalyzerTests", "OneOf.SourceGenerator.AnalyzerTests\OneOf.SourceGenerator.AnalyzerTests.csproj", "{C08F270E-157A-48B9-A7B6-C948FCFC5494}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DE277A67-AD12-4F46-B605-45622A0F4BE1}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/OneOf/OneOfBaseT0.generated.cs
+++ b/OneOf/OneOfBaseT0.generated.cs
@@ -8,7 +8,7 @@ namespace OneOf
         readonly T0 _value0;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0> input)
+        protected internal OneOfBase(OneOf<T0> input)
         {
             _index = input.Index;
             switch (_index)
@@ -26,6 +26,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, TNew> WithType<TNew>() =>
+            new OneOf<T0, TNew>(_index, _value0, default);
+        
 
         public bool IsT0 => _index == 0;
 

--- a/OneOf/OneOfBaseT1.generated.cs
+++ b/OneOf/OneOfBaseT1.generated.cs
@@ -9,7 +9,7 @@ namespace OneOf
         readonly T1 _value1;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1> input)
+        protected internal OneOfBase(OneOf<T0, T1> input)
         {
             _index = input.Index;
             switch (_index)
@@ -29,6 +29,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, TNew>(_index, _value0, _value1, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT2.generated.cs
+++ b/OneOf/OneOfBaseT2.generated.cs
@@ -10,7 +10,7 @@ namespace OneOf
         readonly T2 _value2;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2> input)
         {
             _index = input.Index;
             switch (_index)
@@ -32,6 +32,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, TNew>(_index, _value0, _value1, _value2, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT3.generated.cs
+++ b/OneOf/OneOfBaseT3.generated.cs
@@ -11,7 +11,7 @@ namespace OneOf
         readonly T3 _value3;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3> input)
         {
             _index = input.Index;
             switch (_index)
@@ -35,6 +35,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, TNew>(_index, _value0, _value1, _value2, _value3, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT4.generated.cs
+++ b/OneOf/OneOfBaseT4.generated.cs
@@ -12,7 +12,7 @@ namespace OneOf
         readonly T4 _value4;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4> input)
         {
             _index = input.Index;
             switch (_index)
@@ -38,6 +38,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, TNew>(_index, _value0, _value1, _value2, _value3, _value4, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT5.generated.cs
+++ b/OneOf/OneOfBaseT5.generated.cs
@@ -13,7 +13,7 @@ namespace OneOf
         readonly T5 _value5;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5> input)
         {
             _index = input.Index;
             switch (_index)
@@ -41,6 +41,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT6.generated.cs
+++ b/OneOf/OneOfBaseT6.generated.cs
@@ -14,7 +14,7 @@ namespace OneOf
         readonly T6 _value6;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6> input)
         {
             _index = input.Index;
             switch (_index)
@@ -44,6 +44,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, T6, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, _value6, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT7.generated.cs
+++ b/OneOf/OneOfBaseT7.generated.cs
@@ -15,7 +15,7 @@ namespace OneOf
         readonly T7 _value7;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7> input)
         {
             _index = input.Index;
             switch (_index)
@@ -47,6 +47,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, _value6, _value7, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfBaseT8.generated.cs
+++ b/OneOf/OneOfBaseT8.generated.cs
@@ -16,7 +16,7 @@ namespace OneOf
         readonly T8 _value8;
         readonly int _index;
 
-        protected OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> input)
+        protected internal OneOfBase(OneOf<T0, T1, T2, T3, T4, T5, T6, T7, T8> input)
         {
             _index = input.Index;
             switch (_index)
@@ -50,6 +50,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT0.generated.cs
+++ b/OneOf/OneOfT0.generated.cs
@@ -8,7 +8,7 @@ namespace OneOf
         readonly T0 _value0;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default)
+        internal OneOf(int index, T0 value0 = default)
         {
             _index = index;
             _value0 = value0;
@@ -22,6 +22,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, TNew> WithType<TNew>() =>
+            new OneOf<T0, TNew>(_index, _value0, default);
+        
 
         public bool IsT0 => _index == 0;
 

--- a/OneOf/OneOfT1.generated.cs
+++ b/OneOf/OneOfT1.generated.cs
@@ -9,7 +9,7 @@ namespace OneOf
         readonly T1 _value1;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default)
         {
             _index = index;
             _value0 = value0;
@@ -25,6 +25,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, TNew>(_index, _value0, _value1, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT2.generated.cs
+++ b/OneOf/OneOfT2.generated.cs
@@ -10,7 +10,7 @@ namespace OneOf
         readonly T2 _value2;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default)
         {
             _index = index;
             _value0 = value0;
@@ -28,6 +28,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, TNew>(_index, _value0, _value1, _value2, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT3.generated.cs
+++ b/OneOf/OneOfT3.generated.cs
@@ -11,7 +11,7 @@ namespace OneOf
         readonly T3 _value3;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default)
         {
             _index = index;
             _value0 = value0;
@@ -31,6 +31,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, TNew>(_index, _value0, _value1, _value2, _value3, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT4.generated.cs
+++ b/OneOf/OneOfT4.generated.cs
@@ -12,7 +12,7 @@ namespace OneOf
         readonly T4 _value4;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default)
         {
             _index = index;
             _value0 = value0;
@@ -34,6 +34,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, TNew>(_index, _value0, _value1, _value2, _value3, _value4, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT5.generated.cs
+++ b/OneOf/OneOfT5.generated.cs
@@ -13,7 +13,7 @@ namespace OneOf
         readonly T5 _value5;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default)
         {
             _index = index;
             _value0 = value0;
@@ -37,6 +37,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT6.generated.cs
+++ b/OneOf/OneOfT6.generated.cs
@@ -14,7 +14,7 @@ namespace OneOf
         readonly T6 _value6;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default)
         {
             _index = index;
             _value0 = value0;
@@ -40,6 +40,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, T6, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, _value6, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT7.generated.cs
+++ b/OneOf/OneOfT7.generated.cs
@@ -15,7 +15,7 @@ namespace OneOf
         readonly T7 _value7;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default)
         {
             _index = index;
             _value0 = value0;
@@ -43,6 +43,10 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        public OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TNew> WithType<TNew>() =>
+            new OneOf<T0, T1, T2, T3, T4, T5, T6, T7, TNew>(_index, _value0, _value1, _value2, _value3, _value4, _value5, _value6, _value7, default);
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/OneOf/OneOfT8.generated.cs
+++ b/OneOf/OneOfT8.generated.cs
@@ -16,7 +16,7 @@ namespace OneOf
         readonly T8 _value8;
         readonly int _index;
 
-        OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default)
+        internal OneOf(int index, T0 value0 = default, T1 value1 = default, T2 value2 = default, T3 value3 = default, T4 value4 = default, T5 value5 = default, T6 value6 = default, T7 value7 = default, T8 value8 = default)
         {
             _index = index;
             _value0 = value0;
@@ -46,6 +46,8 @@ namespace OneOf
             };
 
         public int Index => _index;
+
+        
 
         public bool IsT0 => _index == 0;
         public bool IsT1 => _index == 1;

--- a/README.md
+++ b/README.md
@@ -135,6 +135,35 @@ IActionResult Get(string id)
 }
 ```
 
+### WithType method
+
+In order that functions that return OneOf can call other functions that return
+OneOf, the `.WithType()` method allows you to return existing OneOf structs but
+with added types.
+
+**Note:** Unfortunately because of the extended assembly design, OneOf types with
+over 8 parameters cannot use `.WithType`.
+
+```csharp
+public OneOf<string, double> ParseDouble(string input) {
+    if(double.TryParse(input, out var result)) {
+        return result;
+    } else {
+        return input;
+    }
+}
+
+public OneOf<string, double, DateTime, int> ParseDoubleOrUTCDateOrInt (string input) {
+    if (DateTime.TryParseExact(input, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dateResult)) {
+        return dateResult;
+    } else if (int.TryParse(input, out var intResult)) {
+        return intResult;
+    } else {
+        return ParseDouble(input).WithType<DateTime>().WithType<int>();
+    }
+}
+```
+
 ### Reusable OneOf Types using OneOfBase
 
 You can declare a OneOf as a type, either for reuse of the type, or to provide additional members, by inheriting from `OneOfBase`. The derived class will inherit the `.Match`, `.Switch`, and `.TryPick𝑥` methods.


### PR DESCRIPTION
In order that functions that return OneOf can call other functions that return
OneOf, the `.WithType()` method allows you to return existing OneOf structs but
with added types.

**Note:** Unfortunately because of the extended assembly design, OneOf types with
over 8 parameters cannot use `.WithType`.

```csharp
public OneOf<string, double> ParseDouble(string input) {
    if (double.TryParse(input, out var result)) {
        return result;
    } else {
        return input;
    }
}

public OneOf<string, double, DateTime, int> ParseDoubleOrUTCDateOrInt(string input) {
    if (DateTime.TryParseExact(input, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dateResult)) {
        return dateResult;
    }
    else if (int.TryParse(input, out var intResult)) {
        return intResult;
    } else {
        return ParseDouble(input).WithType<DateTime>().WithType<int>();
    }
}
```

resolves #150 