### PR TITLE
Better performance Source Generator

### DIFF
--- a/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
+++ b/OneOf.SourceGenerator.AnalyzerTests/OneOf.SourceGenerator.AnalyzerTests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
+++ b/OneOf.SourceGenerator/OneOf.SourceGenerator.csproj
@@ -36,7 +36,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1">
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1">
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
   </ItemGroup>

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -33,7 +33,8 @@ namespace {AttributeNamespace}
             context.RegisterPostInitializationOutput(ctx => ctx.AddSource($"{AttributeName}.g.cs", _attributeText));
             
             var oneOfClasses = context.SyntaxProvider
-                .CreateSyntaxProvider(
+                .ForAttributeWithMetadataName(
+                    fullyQualifiedMetadataName: $"{AttributeNamespace}.{AttributeName}",
                     predicate: static (s, _) => IsSyntaxTargetForGeneration(s), 
                     transform: static (ctx, _) => GetSemanticTargetForGeneration(ctx))
                 .Where(static m => m is not null)
@@ -44,13 +45,13 @@ namespace {AttributeNamespace}
 
             static bool IsSyntaxTargetForGeneration(SyntaxNode node)
             {
-                return node is ClassDeclarationSyntax {AttributeLists: {Count: > 0}} classDeclarationSyntax 
+                return node is ClassDeclarationSyntax classDeclarationSyntax 
                        && classDeclarationSyntax.Modifiers.Any(SyntaxKind.PartialKeyword);
             }
 
-            static INamedTypeSymbol? GetSemanticTargetForGeneration(GeneratorSyntaxContext context)
+            static INamedTypeSymbol? GetSemanticTargetForGeneration(GeneratorAttributeSyntaxContext context)
             {
-                var symbol = context.SemanticModel.GetDeclaredSymbol(context.Node);
+                var symbol = context.TargetSymbol;
 
                 if (symbol is not INamedTypeSymbol namedTypeSymbol)
                 {


### PR DESCRIPTION
By using `ForAttributeWithMetadataName` we can make the compiler only look at symbols with the specified attribute, instead of looking at all ClassDeclaration symbols.

This means faster generation and also a less laggy IDE experience since not as much work is having to be done on every key stroke.