### PR TITLE
add `global::` to use of OneOf.OneOf in generated code

### DIFF
--- a/OneOf.SourceGenerator.AnalyzerTests/AnalyzerTests.cs
+++ b/OneOf.SourceGenerator.AnalyzerTests/AnalyzerTests.cs
@@ -49,7 +49,7 @@ namespace Foo
 {
     partial class StringOrNumber
     {
-        public StringOrNumber(OneOf.OneOf<string, int, uint> _) : base(_) { }
+        public StringOrNumber(global::OneOf.OneOf<string, int, uint> _) : base(_) { }
 
         public static implicit operator StringOrNumber(string _) => new StringOrNumber(_);
         public static explicit operator string(StringOrNumber _) => _.AsT0;
@@ -85,7 +85,7 @@ namespace Foo
 {
     partial class StringOrNumber
     {
-        public StringOrNumber(OneOf.OneOf<string, int, uint> _) : base(_) { }
+        public StringOrNumber(global::OneOf.OneOf<string, int, uint> _) : base(_) { }
 
         public static implicit operator StringOrNumber(string _) => new StringOrNumber(_);
         public static explicit operator string(StringOrNumber _) => _.AsT0;
@@ -121,7 +121,7 @@ namespace Foo
 {
     partial class StringOrNumber
     {
-        public StringOrNumber(OneOf.OneOf<string, int, uint> _) : base(_) { }
+        public StringOrNumber(global::OneOf.OneOf<string, int, uint> _) : base(_) { }
 
         public static implicit operator StringOrNumber(string _) => new StringOrNumber(_);
         public static explicit operator string(StringOrNumber _) => _.AsT0;
@@ -245,7 +245,7 @@ namespace Foo
 {
     partial class FooBar
     {
-        public FooBar(OneOf.OneOf<global::Foo.Bar.Class1, global::Bar.Class2> _) : base(_) { }
+        public FooBar(global::OneOf.OneOf<global::Foo.Bar.Class1, global::Bar.Class2> _) : base(_) { }
 
         public static implicit operator FooBar(global::Foo.Bar.Class1 _) => new FooBar(_);
         public static explicit operator global::Foo.Bar.Class1(FooBar _) => _.AsT0;

--- a/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
+++ b/OneOf.SourceGenerator.Tests/SourceGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using OneOf;
 using Xunit;
 
 namespace OneOf.SourceGenerator.Tests
@@ -129,6 +130,13 @@ namespace OneOf.SourceGenerator.Tests
             OpenGenericWithClosed<MyClass2> openWithClosed2 = new MyClass();
             Assert.True(openWithClosed2.IsT1);
         }
+
+        [Fact]
+        public void GenerateOneOf_Works_WithTypesFromOneOfNameSpace()
+        {
+            DifferentLibrary.OneOf.JustLibraryClass justLibraryClass = new DifferentLibrary.OneOf.LibraryClass();
+            Assert.True(justLibraryClass.IsT0);
+        }
     }
 
     [GenerateOneOf]
@@ -182,5 +190,17 @@ namespace NotOneOf
     public class OneOf
     {
 
+    }
+}
+
+namespace DifferentLibrary.OneOf
+{
+    public class LibraryClass
+    {
+    }
+
+    [GenerateOneOf]
+    public partial class JustLibraryClass : OneOfBase<LibraryClass>
+    {
     }
 }

--- a/OneOf.SourceGenerator/OneOfGenerator.cs
+++ b/OneOf.SourceGenerator/OneOfGenerator.cs
@@ -84,7 +84,7 @@ namespace {classSymbol.ContainingNamespace.ToDisplayString()}
 
             source.Append($@"
     {{
-        public {classSymbol.Name}(OneOf.OneOf<{oneOfGenericPart}> _) : base(_) {{ }}
+        public {classSymbol.Name}(global::OneOf.OneOf<{oneOfGenericPart}> _) : base(_) {{ }}
 ");
 
             foreach (var (param, arg) in paramArgPairs)


### PR DESCRIPTION
Fixes https://github.com/mcintyre321/OneOf/issues/174