### PR TITLE
Target netstandard2.0 in OneOf.Extended

### DIFF
--- a/OneOf.Extended/OneOf.Extended.csproj
+++ b/OneOf.Extended/OneOf.Extended.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OneOf\OneOf.csproj" />

--- a/OneOf.Extended/OneOf.Extended.csproj
+++ b/OneOf.Extended/OneOf.Extended.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net35;net451;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Authors>Harry McIntyre</Authors>
     <Title>OneOf - Easy Discriminated Unions for c#</Title>
     <Company>Harry McIntyre</Company>

--- a/OneOf/OneOf.csproj
+++ b/OneOf/OneOf.csproj
@@ -22,6 +22,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
We enjoy using OneOf and are also using OneOf.Extended. Unfortunately, OneOf.Extended targets netstandard1.3, but not more recent versions, which introduce vulnerable transitive dependencies to consumers of our libraries.

Our libraries don't target netstandard1.3, but because netstandard1.3 is the highest version and is compatible with our .NET (Core) TFMs, it uses the netstandard1.3 build.
As a result, we're forced to include System.Net.Http as a direct nuget dependency to overwrite the version used.

Here's the .NET CLI reporting the vulnerable dependency:

```
dotnet list OneOf.Extended package --vulnerable --include-transitive

The following sources were used:
   https://api.nuget.org/v3/index.json

Project `OneOf.Extended` has the following vulnerable packages
   [net35]: No vulnerable packages for this framework.
   [net451]: No vulnerable packages for this framework.
   [netstandard1.3]: 
   Transitive Package                    Resolved   Severity   Advisory URL                                     
   > System.Net.Http                     4.3.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Text.RegularExpressions      4.3.0      High       https://github.com/advisories/GHSA-cmhx-cq75-c4mj
```


This PR adds netstandard2.0 as a TFM which will fix the issue for consumers using netstandard2.0 or above.

output:

```
dotnet list OneOf.Extended package --vulnerable --include-transitive

The following sources were used:
   https://api.nuget.org/v3/index.json

Project `OneOf.Extended` has the following vulnerable packages
   [net35]: No vulnerable packages for this framework.
   [net451]: No vulnerable packages for this framework.
   [netstandard1.3]: 
   Transitive Package                    Resolved   Severity   Advisory URL                                     
   > System.Net.Http                     4.3.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Text.RegularExpressions      4.3.0      High       https://github.com/advisories/GHSA-cmhx-cq75-c4mj

   [netstandard2.0]: No vulnerable packages for this framework.
```


---

Update: I conditionally include a package reference to the vulnerable packages to set their minimum version only when building for netstandard1.3. (Also fixed in OneOf main). I can revert this change tho. Our customers don't use netstandard1.3, so building for 2.0 is sufficient for us.

```
dotnet list OneOf.Extended package --vulnerable --include-transitive

The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `OneOf.Extended` has no vulnerable packages given the current sources.
```